### PR TITLE
Refresh getting started guide for Cortex-M platforms

### DIFF
--- a/docs/embedded/arm-cortex-m-guide.mdx
+++ b/docs/embedded/arm-cortex-m-guide.mdx
@@ -1,0 +1,120 @@
+---
+id: arm-cortex-m-guide
+title: ARM Cortex-M Integration Guide
+sidebar_label: ARM Cortex-M
+---
+
+import TryFlow from './steps/try-flow.mdx'
+import CloneSdk from './steps/clone-sdk.md'
+import AddSources from './steps/add-sources.mdx'
+import CorePlatformDependencies from './steps/core-platform-dependencies.mdx'
+import AddBuildId from './steps/add-build-id.mdx'
+import LoggingDependency from './steps/logging-dependency.mdx'
+import RtosPorts from './steps/rtos-ports.mdx'
+import CoredumpDependency from './steps/coredump-dependency.mdx'
+import RegisterAssert from './steps/register-assert.mdx'
+import CreateProjectKey from './steps/create-project-key.mdx'
+import UploadSymbolFile from './steps/upload-symbol-file.mdx'
+import DataTransferTroubleshooting from './steps/data-transfer-troubleshooting.mdx'
+import PostChunksLocally from './steps/post-chunks-locally.mdx'
+import PublishDataToCloud from './steps/publish-data-to-cloud.mdx'
+import DefineFirstTraceEvent from './steps/define-first-trace-event.mdx'
+import DefineFirstHeartbeat from './steps/define-first-heartbeat.mdx'
+import AddCliTestCommands from './steps/add-cli-test-commands.mdx'
+import FwSdkFeatures from './steps/sdk-features.mdx'
+
+## Overview
+
+The following guide will walk you through step-by-step how to integrate and test the Memfault SDK
+for a Cortex-M device using the GNU GCC, Clang, IAR, ARM MDK, or TI ARM Compiler.
+
+<FwSdkFeatures/>
+
+## Pre-Integration
+
+### (Optionally) Collect a coredump capture using GDB
+
+<TryFlow />
+
+## Integration Steps
+
+### Prepare folder for memfault-firmware-sdk & port
+
+<CloneSdk />
+
+### Add Sources to Build System
+
+<AddSources />
+
+### Implement Core Platform Specific Dependencies
+
+<CorePlatformDependencies />
+
+### Add a Unique Identifier to target
+<AddBuildId />
+
+### Implement Logging Dependency
+
+<LoggingDependency />
+
+### Add RTOS Port Files
+
+<RtosPorts />
+
+### Register Assert Handler
+
+<RegisterAssert />
+
+### Implement Coredump Storage Dependency
+
+<CoredumpDependency />
+
+
+### Confirm Integration Links
+
+At this point your project should compile and be able to boot.
+On startup you should see some messaging like:
+
+```
+[I] MFLT: Memfault Build ID: d8d6a047282f025fffa29fa767100f310bc40f80
+```
+
+## Verification & Tuning Steps
+
+With Memfault compiling into your build, it's now time to add some initial instrumentation, and test the integration!
+
+### Define First Trace Event
+
+<DefineFirstTraceEvent />
+
+### Define First Heartbeat
+
+
+<DefineFirstHeartbeat />
+
+### Add Test Commands to CLI
+
+<AddCliTestCommands/>
+
+
+### Post data Locally
+
+<PostChunksLocally />
+
+### Upload Symbol File
+
+<UploadSymbolFile/>
+
+### Troubleshooting Data Transfer
+
+<DataTransferTroubleshooting/>
+
+
+## Data Transport Steps
+
+With data collection verified locally, the final step is to push data automatically to the Memfault
+cloud for analysis.
+
+### Push Data to Cloud over Device Transport
+
+<PublishDataToCloud/>

--- a/docs/embedded/arm-gcc-guide-coredumps.md
+++ b/docs/embedded/arm-gcc-guide-coredumps.md
@@ -3,7 +3,7 @@ id: arm-gcc-guide-coredumps
 title: ARM GCC Getting Started Guide
 sidebar_label: ARM GCC Guide
 ---
-
+ 
 This tutorial will go over integrating the **panics** component of the
 [Memfault Firmware SDK](https://github.com/memfault/memfault-firmware-sdk) into
 a system that is using the

--- a/docs/embedded/esp32-guide.md
+++ b/docs/embedded/esp32-guide.md
@@ -1,7 +1,7 @@
 ---
 id: esp32-guide
-title: ESP32 Getting Started Guide
-sidebar_label: ESP32 Guide
+title: ESP32 ESP-IDF Integration Guide
+sidebar_label: ESP32 ESP-IDF
 ---
 
 This tutorial will go over integrating the **panics** component of the

--- a/docs/embedded/esp8266-rtos-sdk-guide.md
+++ b/docs/embedded/esp8266-rtos-sdk-guide.md
@@ -1,7 +1,7 @@
 ---
 id: esp8266-rtos-sdk-guide
-title: ESP8266 RTOS SDK Guide
-sidebar_label: ESP8266 RTOS SDK Guide
+title: ESP8266 RTOS Integration Guide
+sidebar_label: ESP8266 RTOS SDK
 ---
 
 ## Overview

--- a/docs/embedded/introduction.md
+++ b/docs/embedded/introduction.md
@@ -42,11 +42,10 @@ an error, and publish data to the Memfault cloud:
 
 | MCU Architecture |                  Getting Started Guide                   |
 | ---------------- | :------------------------------------------------------: |
-| ARM Cortex-M     |      [ARM GCC Guide](/docs/embedded/arm-gcc-guide)       |
-| ARM Cortex-M     |      [ARM IAR Guide](/docs/embedded/arm-iar-guide)       |
-| ARM Cortex-M     |      [ARM MDK Guide](/docs/embedded/arm-mdk-guide)       |
-| nRF Connect SDK  | [nRF Connect SDK ](/docs/embedded/nrf-connect-sdk-guide) |
-| ESP32            | [Espressif IoT Development](/docs/embedded/esp32-guide)  |
+| ARM Cortex-M    |      [ARM Cortex-M Integration Guide](/docs/embedded/arm-cortex-m-guide)       |
+| nRF Connect SDK  | [nRF Connect SDK Integration Guide](/docs/embedded/nrf-connect-sdk-guide) |
+| ESP32 ESP-IDF           | [ESP32 ESP-IDF Integration Guide](/docs/embedded/esp32-guide)  |
+| ESP8266            | [ESP8266 RTOS Integration Guide](/docs/embedded/esp8266-rtos-sdk-guide)  |
 
 </center>
 

--- a/docs/embedded/nrf-connect-sdk-guide.md
+++ b/docs/embedded/nrf-connect-sdk-guide.md
@@ -1,7 +1,7 @@
 ---
 id: nrf-connect-sdk-guide
-title: nRF Connect SDK Integration
-sidebar_label: nRF Connect SDK Guide
+title: nRF Connect SDK Integration Guide
+sidebar_label: nRF Connect SDK
 ---
 
 In this guide we will walk through the steps for integrating the

--- a/docs/embedded/self-serve-local-testing.mdx
+++ b/docs/embedded/self-serve-local-testing.mdx
@@ -21,7 +21,7 @@ and verify that everything is working properly.
 <DefineFirstTraceEvent />
 
 ### Define First Heartbeat
-
+ 
 
 <DefineFirstHeartbeat />
 

--- a/docs/embedded/steps/add-build-id.mdx
+++ b/docs/embedded/steps/add-build-id.mdx
@@ -39,9 +39,11 @@ Update your build system to invoke the `scripts/fw_build_id.py` script on your E
 
 For example, using CMake, this can be achieved by adding a custom command to the target:
 
+```bash
 add_custom_command(TARGET ${YOUR_EXECUTABLE_NAME} POST_BUILD
   COMMAND python ${MEMFAULT_SDK_ROOT}/scripts/fw_build_id.py ${YOUR_EXECUTABLE_NAME}
 )
+```
 
 :::info
 The script depends on `pyelftools` so make sure you have run `pip install pyelftools` or added to your `requirements.txt`

--- a/docs/embedded/steps/add-sources.mdx
+++ b/docs/embedded/steps/add-sources.mdx
@@ -46,9 +46,8 @@ and `${MEMFAULT_COMPONENTS_INC_FOLDERS}` to your target includes accordingly
 <details>
   <summary>Other</summary>
 
-1. add `$MEMFAULT_FIRMWARE_SDK/components/[core, util, panics, metrics]/include` to the include
-   paths for your project
-2. add `$MEMFAULT_FIRMWARE_SDK/include` to the include paths for your project
+1. add `$MEMFAULT_FIRMWARE_SDK/components/include` to the include paths for your project
+2. add `$MEMFAULT_FIRMWARE_SDK/ports/include` to the include paths for your project
 3. add the sources under `$MEMFAULT_FIRMWARE_SDK/components/[core, util, panics, metrics]/src/**/*.c` to your project
 
 </details>

--- a/docs/embedded/steps/clone-sdk.md
+++ b/docs/embedded/steps/clone-sdk.md
@@ -27,11 +27,11 @@ project:
 memfault/
 //...
 ├── memfault-firmware-sdk (submodule)
-| #
+| # Files where port to your platform will be implemented
 ├── memfault_platform_port.c
 ├── memfault_platform_coredump_regions.c
 |
-| # Configuration Files
+| # Configuration Headers
 ├── memfault_metrics_heartbeat_config.def
 └── memfault_trace_reason_user_config.def
 └── memfault_platform_log_config.h

--- a/docs/embedded/steps/publish-data-to-cloud.mdx
+++ b/docs/embedded/steps/publish-data-to-cloud.mdx
@@ -1,11 +1,20 @@
 Extensive details about how data from the Memfault SDK makes it to the cloud
 [can be found here](/docs/embedded/data-from-firmware-to-the-cloud). In short, the Memfault SDK
 packetizes data into "chunks" that must be pushed to the Memfault cloud via the
-[chunk REST endpoint](https://api-docs.memfault.com/?version=latest#66b0e390-2c3e-4c0d-b6c2-836a287b9e5f)
+[chunk REST endpoint](https://api-docs.memfault.com/?version=latest#66b0e390-2c3e-4c0d-b6c2-836a287b9e5f).
 
 The Memfault SDK exposes an api that packatizes Memfault data into "chunks".
 These "chunks" need to be forwarded to the Memfault Cloud (either directly via HTTPs or indirectly via a
 gateway device such as a computer or mobile application)
+
+:::info
+If you cannot post data directly using HTTP, no problem at all. In fact, that is one of the most common configurations.
+In these setups, data can be proxied from the MCU to a device which can perform a HTTP request over transports such as UART, BLE, COAP, LoRa, Zigbee, etc).
+The size of a "chunk" is fully configurable by you can be tuned to best match your transport requirements. All message
+re-assembly is dealt with by Memfault in the cloud.
+:::
+
+
 
 ```c
 #include "memfault/components.h"
@@ -26,6 +35,10 @@ bool try_send_memfault_data(void) {
 }
 
 void send_memfault_data(void) {
+  if (memfault_packetizer_data_available()) {
+    return false; // no new data to send
+  }
+
   // [... user specific logic deciding when & how much data to send
   while (try_send_memfault_data()) { }
 }

--- a/docs/embedded/steps/sdk-features.mdx
+++ b/docs/embedded/steps/sdk-features.mdx
@@ -1,0 +1,14 @@
+Upon completion of the integration, the following subcomponents will be added to
+your system!
+
+- [Reboot Reason Tracking](/docs/embedded/reboot-reason-tracking)
+
+![](/img/docs/embedded/reboot-reason-chart.png)
+
+- [Error Tracking with Trace Events](/docs/embedded/trace-events)
+
+![](/img/docs/embedded/trace-reason-example.png)
+
+- [RAM-backed stack dump Collection](/docs/embedded/coredumps)
+
+![](/img/docs/embedded/logs-with-coredump.png)

--- a/sidebars.js
+++ b/sidebars.js
@@ -22,19 +22,17 @@ module.exports = {
             "embedded/introduction",
             {
                 type: "category",
-                label: "Getting Started",
+                label: "Getting Started Guides",
                 items: [
-                    "embedded/arm-gcc-guide",
-                    "embedded/arm-iar-guide",
-                    "embedded/arm-mdk-guide",
-                    "embedded/esp32-guide",
+                    "embedded/arm-cortex-m-guide",
                     "embedded/nrf-connect-sdk-guide",
+                    "embedded/esp32-guide",
                     "embedded/esp8266-rtos-sdk-guide",
                 ],
             },
             {
                 type: "category",
-                label: "Subsystem Integration Guides",
+                label: "Subsystem Guides",
                 items: [
                     /* Order in which subsystems ideally get integrated */
                     "embedded/coredumps",


### PR DESCRIPTION
- Consolidates the compiler-specific ARM Cortex-M getting started guides into one centralized document.
- Makes use of MDX for better re-use of documentation blocks
- Broke guide into 3 parts:
  - "Integration"  - Walks through how to add the memfault-firmware-sdk to a project and the exact dependency functions that need to be implemented
  - "Verification & Tuning Steps" - Walks through how to test the SDK and start adding custom instrumentation
  - "Data Transport" - Walks through how to export data from Memfault and publish to Memfault's cloud in a programmatic way 