### PR TITLE
Support ?embed mode during SSR too

### DIFF
--- a/src/components/EmbedMode.js
+++ b/src/components/EmbedMode.js
@@ -1,17 +1,16 @@
 import React, { useMemo } from "react";
+import { useLocation } from "react-router";
 
-const DEFAULTS = { enabled: false, settings: {} };
-
-const EmbedModeContext = React.createContext(DEFAULTS);
+const EmbedModeContext = React.createContext({ enabled: false, settings: {} });
 
 /** Support for embedding the docs in an iframe from our application */
 export function EmbedModeProvider({ children }) {
+    const { search } = useLocation();
     const value = useMemo(() => {
-        if (typeof window === "undefined") return DEFAULTS;
-
-        const params = new URL(document.location).searchParams;
-        return { enabled: params.get("embed") != null, settings: {} };
-    }, []);
+        // Searching the string instead of parsing params to avoid having to
+        // import URLSearchParams for Node in the browser unnecessarily.
+        return { enabled: search.includes("embed"), settings: {} };
+    }, [search]);
     return (
         <EmbedModeContext.Provider value={value}>
             {value.enabled ? (


### PR DESCRIPTION
This wasn't happening during development because the local server
doesn't do SSR like the production one does (bad idea IMO, having a
local server that does the same as production would be great).

I noticed the header, footer and sidebar were flashing for a little bit
on the Memfault app, and I thought this might be because of SSR, and how
`EmbedModeProvider` doesn't support it.

With this change, `EmbedModeProvider` gets the search params from the
React router instead of from `document`, which should work both during
SSR as well as in the browser.