### PR TITLE
Improve documentation around build system integration

### DIFF
--- a/docs/embedded/steps/add-build-id.mdx
+++ b/docs/embedded/steps/add-build-id.mdx
@@ -12,7 +12,7 @@ Memfault has two ways to add a Build ID to a target. Select the appropriate one 
   <summary>GNU Build ID (Requires Use of GNU GCC Compiler)</summary>
 
 1. Add `-Wl,--build-id` to flags passed to linker via GCC
-2. Add `-DMEMFAULT_USE_GNU_BUILD_ID=1` CFLAG to CC invocation
+2. Add `#define MEMFAULT_USE_GNU_BUILD_ID 1` to `third_party/memfault/memfault_platform_config.h`
 3. Add the following snippet to your projects linker script (`.ld` file)
    where "FLASH" below will match the name of the MEMORY section
    read-only data and text is placed in.

--- a/docs/embedded/steps/add-sources.mdx
+++ b/docs/embedded/steps/add-sources.mdx
@@ -5,14 +5,21 @@ and follow the steps to add the sources to your target
   <summary>Make</summary>
 
 ```
-MEMFAULT_SDK_ROOT := <YOUR_PROJECT_ROOT>/third_party/memfault
-include ${MEMFAULT_SDK_ROOT}/makefiles/MemfaultWorker.mk
+MEMFAULT_PORT_ROOT := <YOUR_PROJECT_ROOT>/third_party/memfault
+MEMFAULT_SDK_ROOT := $(MEMFAULT_PORT_ROOT)/memfault-firmware-sdk
 
 MEMFAULT_COMPONENTS := core util panics metrics
 include $(MEMFAULT_SDK_ROOT)/makefiles/MemfaultWorker.mk
 
-<YOUR_SRC_FILES> += $(MEMFAULT_COMPONENTS_SRCS)
-<YOUR_INCLUDE_PATHS> += $(MEMFAULT_COMPONENTS_INC_FOLDERS)
+<YOUR_SRC_FILES> += \
+  $(MEMFAULT_COMPONENTS_SRCS) \
+  $(MEMFAULT_PORT_ROOT)/memfault_platform_port.c \
+  $(MEMFAULT_PORT_ROOT)/memfault_platform_coredump_regions.c
+
+<YOUR_INCLUDE_PATHS> += \
+  $(MEMFAULT_COMPONENTS_INC_FOLDERS) \
+  $(MEMFAULT_SDK_ROOT)/ports/include \
+  $(MEMFAULT_PORT_ROOT)
 ```
 
 :::info
@@ -26,14 +33,22 @@ Be sure to update `YOUR_SRC_FILES`, `YOUR_INCLUDE_PATHS`, and
   <summary>CMake</summary>
 
 ```
-set(MEMFAULT_SDK_ROOT <YOUR_PROJECT_ROOT>/third_party/memfault)
+set(MEMFAULT_PORT_ROOT <YOUR_PROJECT_ROOT>/third_party/memfault)
+set(MEMFAULT_SDK_ROOT ${MEMFAULT_PORT_ROOT}/memfault-firmware-sdk)
+
 list(APPEND MEMFAULT_COMPONENTS core util panics metrics)
 include(${MEMFAULT_SDK_ROOT}/cmake/Memfault.cmake)
 memfault_library(${MEMFAULT_SDK_ROOT} MEMFAULT_COMPONENTS
  MEMFAULT_COMPONENTS_SRCS MEMFAULT_COMPONENTS_INC_FOLDERS)
 
-# ${MEMFAULT_COMPONENTS_SRCS} contains the sources
-# needed for the library and ${MEMFAULT_COMPONENTS_INC_FOLDERS} contains the include paths
+# Add the following to your target sources:
+#   ${MEMFAULT_COMPONENTS_SRCS}
+#   ${MEMFAULT_PORT_ROOT}/memfault_platform_port.c
+#   ${MEMFAULT_PORT_ROOT}/memfault_platform_coredump_regions.c
+#
+# Add the following to your target includes
+#   ${MEMFAULT_COMPONENTS_INC_FOLDERS}
+#   ${MEMFAULT_PORT_ROOT}
 ```
 
 :::info
@@ -49,5 +64,7 @@ and `${MEMFAULT_COMPONENTS_INC_FOLDERS}` to your target includes accordingly
 1. add `$MEMFAULT_FIRMWARE_SDK/components/include` to the include paths for your project
 2. add `$MEMFAULT_FIRMWARE_SDK/ports/include` to the include paths for your project
 3. add the sources under `$MEMFAULT_FIRMWARE_SDK/components/[core, util, panics, metrics]/src/**/*.c` to your project
+4. add `third_party/memfault/memfault_platform_port.c` & `third_party/memfault/memfault_platform_coredump_regions.c` sources to project
+5. add `third_party/memfault/` to the include paths for your project
 
 </details>

--- a/docs/embedded/steps/clone-sdk.md
+++ b/docs/embedded/steps/clone-sdk.md
@@ -15,6 +15,7 @@ touch memfault_platform_config.h
 touch memfault_trace_reason_user_config.def
 touch memfault_metrics_heartbeat_config.def
 touch memfault_platform_log_config.h
+touch memfault_platform_config.h
 
 # Add memfault repo as submodule, subtree, or copy in as source directly
 git submodule add https://github.com/memfault/memfault-firmware-sdk.git memfault-firmware-sdk
@@ -35,4 +36,5 @@ memfault/
 ├── memfault_metrics_heartbeat_config.def
 └── memfault_trace_reason_user_config.def
 └── memfault_platform_log_config.h
+└── memfault_platform_config.h
 ```

--- a/docs/embedded/steps/logging-dependency.mdx
+++ b/docs/embedded/steps/logging-dependency.mdx
@@ -7,7 +7,7 @@ Based on your setup, choose one of the options below:
 <details>
   <summary>Platform does logging via Macros</summary>
 
-1. Add `-DMEMFAULT_PLATFORM_HAS_LOG_CONFIG=1` to targets compiler flags
+1. Add `#define MEMFAULT_PLATFORM_HAS_LOG_CONFIG 1` to `third_party/memfault/memfault_platform_config.h`
 2. Remap Memfault logging macros to platform logging macros by adding the following
 macros to the `memfault_platform_log_config.h` file created earlier.
 


### PR DESCRIPTION
- List out user port files that need to be added to build
- Update documentation to mention `memfault_platform_config.h` which can be used to configure the SDK
- Fix typo in Makefile build system setup