### PR TITLE
Add explicit steps for metric and reboot reason dependencies

### DIFF
--- a/docs/embedded/arm-cortex-m-guide.mdx
+++ b/docs/embedded/arm-cortex-m-guide.mdx
@@ -22,6 +22,8 @@ import DefineFirstTraceEvent from './steps/define-first-trace-event.mdx'
 import DefineFirstHeartbeat from './steps/define-first-heartbeat.mdx'
 import AddCliTestCommands from './steps/add-cli-test-commands.mdx'
 import FwSdkFeatures from './steps/sdk-features.mdx'
+import MetricTimerDependency from './steps/metric-timer-dependency.mdx'
+import RebootTrackingDependency from './steps/reboot-tracking-dependency.mdx'
 
 ## Overview
 
@@ -46,18 +48,24 @@ for a Cortex-M device using the GNU GCC, Clang, IAR, ARM MDK, or TI ARM Compiler
 
 <AddSources />
 
-### Implement Core Platform Specific Dependencies
+### Core Dependencies
 
 <CorePlatformDependencies />
 
-### Add a Unique Identifier to target
-<AddBuildId />
+### Reboot Tracking Dependencies
 
-### Implement Logging Dependency
+<RebootTrackingDependency />
+
+### Logging Dependency
 
 <LoggingDependency />
 
-### Add RTOS Port Files
+
+### Timer Dependencies
+
+<MetricTimerDependency />
+
+### RTOS Port Files
 
 <RtosPorts />
 
@@ -68,6 +76,9 @@ for a Cortex-M device using the GNU GCC, Clang, IAR, ARM MDK, or TI ARM Compiler
 ### Implement Coredump Storage Dependency
 
 <CoredumpDependency />
+
+### Add a Unique Identifier to target
+<AddBuildId />
 
 
 ### Confirm Integration Links

--- a/docs/embedded/steps/core-platform-dependencies.mdx
+++ b/docs/embedded/steps/core-platform-dependencies.mdx
@@ -10,21 +10,15 @@ You can copy the template below into your project and fill in accordingly.
 
 #include <stdbool.h>
 
-static uint8_t s_event_storage[1024];
-
-MEMFAULT_PUT_IN_SECTION(".noinit")
-static uint8_t s_reboot_tracking[MEMFAULT_REBOOT_TRACKING_REGION_SIZE];
-
-
 void memfault_platform_get_device_info(sMemfaultDeviceInfo *info) {
   // See https://mflt.io/version-nomenclature for more context
   *info = (sMemfaultDeviceInfo) {
      // An ID that uniquely identifies the device in your fleet
      // (i.e serial number, mac addr, chip id, etc)
-    .device_serial = "",
+    .device_serial = "DEMOSERIAL",
      // A name to represent the firmware running on the MCU.
      // (i.e "ble-fw", "main-fw", or a codename for your project)
-    .software_type = "",
+    .software_type = "app-fw",
      // The version of the "software_type" currently running.
      // "software_type" + "software_version" must uniquely represent
      // a single binary
@@ -32,19 +26,20 @@ void memfault_platform_get_device_info(sMemfaultDeviceInfo *info) {
      // The revision of hardware for the device. This value must remain
      // the same for a unique device.
      // (i.e evt, dvt, pvt, or rev1, rev2, etc)
-    .hardware_version = "",
+    .hardware_version = "dvt1",
   };
 }
 
 //! Last function called after a coredump is saved. Should perform
 //! any final cleanup and then reset the device
 void memfault_platform_reboot(void) {
-   // i.e NVIC_SystemReset();
+   // TODO: Perform any final system cleanup and issue a software reset
+   // (i.e NVIC_SystemReset())
    while (1) { } // unreachable
 }
 
 bool memfault_platform_time_get_current(sMemfaultCurrentTime *time) {
-  // If device does not track time, stub can be left as is
+  // TODO: If device does not track time, stub can be left as is
   //
   // If the device tracks real time, update 'unix_timestamp_secs' with seconds since epoch
   // _and_ change the return value to true. This will cause events logged by the SDK to be
@@ -66,10 +61,7 @@ int memfault_platform_boot(void) {
 
   memfault_build_info_dump();
 
-  sResetBootupInfo reset_info = { 0 };
-  memfault_reboot_reason_get(&reset_info);
-  memfault_reboot_tracking_boot(s_reboot_tracking, &reset_info);
-
+  static uint8_t s_event_storage[1024];
   const sMemfaultEventStorageImpl *evt_storage =
       memfault_events_storage_boot(s_event_storage, sizeof(s_event_storage));
   memfault_trace_event_boot(evt_storage);

--- a/docs/embedded/steps/coredump-dependency.mdx
+++ b/docs/embedded/steps/coredump-dependency.mdx
@@ -18,15 +18,15 @@ static sMfltCoredumpRegion s_coredump_regions[1];
 
 //! Truncates the region if it's outside the bounds of RAM
 size_t memfault_platform_sanitize_address_range(void *start_addr, size_t desired_size) {
-  const uint32_t ram_start = YOUR_PLATFORM_SRAM_START;
-  const uint32_t ram_end = YOUR_PLATFORM_SRAM_END;
+  // TODO: Populate with actual boundaries of RAM for target MCU
+  const uint32_t ram_start = 0x00000000;
+  const uint32_t ram_end = 0xFFFFFFFF;
 
   if ((uint32_t)start_addr >= ram_start && (uint32_t)start_addr < ram_end) {
     return MEMFAULT_MIN(desired_size, ram_end - (uint32_t)start_addr);
   }
   return 0;
 }
-
 
 //! The RAM regions to collect in a coredump capture
 const sMfltCoredumpRegion *memfault_platform_coredump_get_regions(
@@ -142,4 +142,3 @@ void memfault_platform_coredump_storage_clear(void) {
 ```
 
 </details>
-

--- a/docs/embedded/steps/metric-timer-dependency.mdx
+++ b/docs/embedded/steps/metric-timer-dependency.mdx
@@ -1,0 +1,47 @@
+The memfault metric subsystem requires a repeating timer in order to collect "heartbeats" and a time since boot
+
+<details>
+
+<summary> FreeRTOS </summary>
+
+Add the following file to your build system:
+
+```
+  ${MEMFAULT_SDK_ROOT}/ports/freertos/memfault_metrics_freertos.c
+```
+
+</details>
+
+<details>
+
+<summary> nRF5 SDK </summary>
+
+Add the following file to your build system:
+
+```
+  ${MEMFAULT_SDK_ROOT}/ports/nrf5_sdk/memfault_platform_metrics.c
+```
+
+</details>
+
+<details>
+
+<summary> Template </summary>
+
+```
+//! @file memfault_platform_port.c
+
+bool memfault_platform_metrics_timer_boot(uint32_t period_sec, MemfaultPlatformTimerCallback callback) {
+  // Schedule a timer to invoke callback() repeatedly after period_sec
+  return true;
+}
+```
+
+```
+uint64_t memfault_platform_get_time_since_boot_ms(void) {
+  // Return time since boot in ms, this is used for relative timings.
+  return 0;
+}
+```
+
+</details>

--- a/docs/embedded/steps/reboot-tracking-dependency.mdx
+++ b/docs/embedded/steps/reboot-tracking-dependency.mdx
@@ -1,0 +1,149 @@
+Memfault has a module for tracking and reporting what resets are taking place on your platform.
+
+<details>
+
+<summary> nRF5 SDK </summary>
+
+Add the following file to your build system:
+
+```
+  ${MEMFAULT_SDK_ROOT}/ports/nrf5_sdk/memfault_platform_metrics.c
+```
+
+Add call to `memfault_platform_reboot_tracking_boot()` from `memfault_platform_boot()`
+
+```diff
+//! @file memfault_platform_port.c
+
+int memfault_platform_boot(void) {
++ memfault_platform_reboot_tracking_boot();
++
+  memfault_build_info_dump();
+}
+```
+
+</details>
+
+<details>
+
+<summary> Template </summary>
+
+#### Allocate noinit region
+
+A region of RAM that does not get initialized across resets needs to be allocated for saving
+information about resets that are about to take place.
+
+
+```diff
+//! @file memfault_platform_port.c
+
++ MEMFAULT_PUT_IN_SECTION(".noinit")
++ static uint8_t s_reboot_tracking[MEMFAULT_REBOOT_TRACKING_REGION_SIZE];
+```
+
+:::note
+You will need to update your linker script for the variable to be in noinit RAM.
+:::
+
+#### Collect reboot info
+
+```diff
+//! @file memfault_platform_port.c
+
+int memfault_platform_boot(void) {
++  sResetBootupInfo reset_info = { 0 };
++  memfault_reboot_reason_get(&reset_info);
++  memfault_reboot_tracking_boot(s_reboot_tracking, &reset_info);
+  memfault_build_info_dump();
+}
+```
+
+
+#### Add `memfault_reboot_reason_get()`
+
+<details>
+
+<summary> EFM/EFR (Gecko SDK) </summary>
+
+Add the following file to your build system:
+
+```
+  ${MEMFAULT_SDK_ROOT}/ports/emlib/rmu_reboot_tracking.c
+```
+
+</details>
+
+<details>
+
+<summary> STM32CubeF4 </summary>
+
+Add the following file to your build system:
+
+```
+  ${MEMFAULT_SDK_ROOT}/ports/stm32cube/f4/rcc_reboot_tracking.c
+```
+
+</details>
+
+<details>
+
+<summary> STM32CubeL4 </summary>
+
+Add the following file to your build system:
+
+```
+  ${MEMFAULT_SDK_ROOT}/ports/stm32cube/l4/rcc_reboot_tracking.c
+```
+
+</details>
+
+<details>
+
+<summary> STM32CubeWB </summary>
+
+Add the following file to your build system:
+
+```
+  ${MEMFAULT_SDK_ROOT}/ports/stm32cube/wb/rcc_reboot_tracking.c
+```
+
+</details>
+
+<details>
+
+<summary> NXP S32 SDK </summary>
+
+Add the following file to your build system:
+
+```
+  ${MEMFAULT_SDK_ROOT}/ports/s32sdk/rcm_reboot_tracking.c
+```
+
+</details>
+
+<details>
+
+<summary> Other </summary>
+
+Implement the following function for your MCU. The ports listed above serve as a good reference.
+
+
+```c
+//! @file memfault_platform_port.c
+
+void memfault_reboot_reason_get(sResetBootupInfo *info) {
+  const uint32_t reset_cause = 0; // TODO: Populate with MCU reset reason
+  eMemfaultRebootReason reset_reason = kMfltRebootReason_Unknown;
+
+  // TODO: Convert MCU specific reboot reason to memfault enum
+
+  *info = (sResetBootupInfo) {
+    .reset_reason_reg = reset_cause,
+    .reset_reason = reset_reason,
+  };
+}
+```
+
+</details>
+
+</details>

--- a/docs/embedded/steps/rtos-ports.mdx
+++ b/docs/embedded/steps/rtos-ports.mdx
@@ -10,7 +10,6 @@ Expand the tab for the one applies to your system below in order to pick them up
 ```
   ${MEMFAULT_SDK_ROOT}/ports/freertos/src/memfault_core_freertos.c
   ${MEMFAULT_SDK_ROOT}/ports/freertos/memfault_freertos_ram_regions.c
-  ${MEMFAULT_SDK_ROOT}/ports/freertos/memfault_metrics_freertos.c
   ${MEMFAULT_SDK_ROOT}/ports/freertos/memfault_panics_freertos.c
 ```
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -15,7 +15,7 @@ module.exports = {
             "embedded/uploading-software-versions",
             "platform/jira-integration",
             "platform/fleet-wide-metrics",
-            "platform/bulk-device-upload",
+            /* "platform/bulk-device-upload", */
             /* Mentions features to be released: "platform/sso", */
             /* Mentions features to be released: "platform/api-keys", */
             /* Draft: "platform/releasing-firmware", */


### PR DESCRIPTION
- Broke reboot tracking into it's own section. Some platforms have a pre setup noinit region but others require their own port. 
- Added section for metric timer dependencies 
- Moved build id later into the step sequence after all compilation deps have been pulled in
- Added example field names to device info populated in `memfault_platform_get_device_info()`
