### PR TITLE
Add prettier as dev dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ yarn-error.log*
 !.yarn/versions
 .pnp.*
 
+.idea/

--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,0 +1,6 @@
+overrides:
+  - files: "*.md"
+    options:
+      proseWrap: always
+  - files: "*.css"
+    tabWidth: 4

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
         "build": "docusaurus build",
         "swizzle": "docusaurus swizzle",
         "deploy": "docusaurus deploy",
-        "serve": "docusaurus serve"
+        "serve": "docusaurus serve",
+        "lint:prettier:base": "prettier '**/*.{js,jsx,ts,tsx,md}'",
+        "lint:prettier:fix": "yarn lint:prettier:base --write",
+        "lint:prettier": "yarn lint:prettier:base --check"
     },
     "dependencies": {
         "@docusaurus/core": "2.0.0-alpha.70",
@@ -32,6 +35,7 @@
         ]
     },
     "devDependencies": {
-        "netlify-cli": "^2.30.0"
+        "netlify-cli": "^2.30.0",
+        "prettier": "^2.2.1"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10823,6 +10823,11 @@ prepend-http@^2.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
 
+prettier@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
+  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
+
 pretty-error@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/pretty-error/-/pretty-error-2.1.2.tgz#be89f82d81b1c86ec8fdfbc385045882727f93b6"


### PR DESCRIPTION
I added prettier as dev dependency.
Added the same .rc file and `lint:...` package.json scripts we've got in the monorepo.
I did not add any CI scripts whatsoever. I'm not sure whether / how that would jive with Forestry.
