### PR TITLE
Improve documentation around exporting memfault chunks via CLI

### DIFF
--- a/docs/embedded/arm-cortex-m-guide.mdx
+++ b/docs/embedded/arm-cortex-m-guide.mdx
@@ -107,7 +107,7 @@ instrumentation, and test the integration!
 
 <AddCliTestCommands />
 
-### Post data Locally
+### Post Data to Cloud via Local Debug Setup
 
 <PostChunksLocally />
 
@@ -124,6 +124,6 @@ instrumentation, and test the integration!
 With data collection verified locally, the final step is to push data
 automatically to the Memfault cloud for analysis.
 
-### Push Data to Cloud over Device Transport
+### Post Data to Cloud via Device Transport
 
 <PublishDataToCloud />

--- a/docs/embedded/export-chunks-over-console.mdx
+++ b/docs/embedded/export-chunks-over-console.mdx
@@ -1,21 +1,16 @@
 ---
 id: export-chunks-over-console
-title: Exporting Chunks Over Console
-sidebar_label: Exporting Data Collected
+title: Post chunks with Memfault CLI
+sidebar_label: Extract Chunks with Memfault CLI
 ---
 
-:::caution
-
-This guide assumes you have already installed the
-[Memfault CLI tool](/docs/ci/install-memfault-cli).
-
-:::
+import PostChunksWithMemfaultCli from "./steps/post-data-with-memfault-cli.mdx";
 
 In the following tutorial we will discuss how to use the Memfault SDK data
 export API to collect "chunks" from a device and then post them to the Memfault
 cloud for analysis.
 
-## Add call to `memfault_data_export_dump_chunks`
+### Add call to `memfault_data_export_dump_chunks`
 
 The data export module uses the SDK data
 [packetizer APIs](https://mflt.io/data-to-cloud) to read the data which has been
@@ -34,7 +29,9 @@ void some_periodic_task_or_cli_cmd(void) {
 }
 ```
 
-## Optional: Override where data is exported to
+<details>
+
+<summary> Optional: Override where data is exported to </summary>
 
 By default, the data_export module will dump results to the console using the
 `memfault_platform_log` implementation that was added as part of the
@@ -51,51 +48,13 @@ void memfault_data_export_base64_encoded_chunk(const char *chunk_str) {
 }
 ```
 
-## Save extracted data to file
+</details>
 
-Now that you have wired up the export facilities, generate some Memfault data,
-trigger a data export, and save it to a file.
-
-You should see strings with the format: `MC:BASE64_ENCODED_CHUNK:` in the dump.
-
-:::note
-
-It's perfectly fine for other logs to be interleaved with the exported data.
-
-:::
-
-Here's an example of some
-[Precanned Data Payloads](/docs/embedded/test-patterns-for-chunks-endpoint) that
-I've saved to
-[test-pattern-data-export.txt](/downloads/docs/test-patterns-for-chunks-endpoint/test-pattern-data-export.txt)
-from a dump over a console:
-
-```
-[00:00:01] INFO: System Booting!
-[00:00:02] DEBUG: System Initialized
-[00:00:10] INFO: MC:SFQCpwIBAwEHalRFU1RTRVJJQUwKbXRlc3Qtc29mdHdhcmUJajEuMC4wLXRlcw==:
-[00:00:20] DEBUG: Another Log!
-[00:00:30] INFO: MC:gCx0Bm10ZXN0LWhhcmR3YXJlBKEBoXJjaHVua190ZXN0X3N1Y2Nlc3MBMeQ=:
-[00:00:35] DEBUG: Etc ...
-```
-
-## Grab Project Key from Memfault UI
+### Grab Project Key from Memfault UI
 
 A Project key will be needed in order to communicate with Memfault's web
 services. Go to [https://app.memfault.com/](https://app.memfault.com/), navigate
 to the project you want to use and select 'Settings'→'General'. The 'Project
 Key' listed is what you will want to use.
 
-## Post Data to Memfault Cloud using CLI Tool
-
-Now that you have collected some data, you can post it to the Memfault cloud by
-using the [Memfault CLI tool](/docs/ci/install-memfault-cli).
-
-```bash
-$ memfault --project-key ${YOUR_PROJECT_KEY} post-chunk --encoding sdk_data_export test-pattern-data-export.txt
-Found 2 Chunks. Sending Data ...
-Success
-```
-
-At this point you can navigate back to the Memfault UI and view the data that
-has been sent!
+<PostChunksWithMemfaultCli />

--- a/docs/embedded/steps/post-chunks-locally.mdx
+++ b/docs/embedded/steps/post-chunks-locally.mdx
@@ -1,3 +1,6 @@
+import PostChunksWithMemfaultCli from "./post-data-with-memfault-cli.mdx";
+import PostChunksWithGdb from "./post-data-with-gdb.mdx";
+
 Prior to having an end-to-end transport in place, Memfault data can be exported
 over any serial connection or via GDB directly.
 
@@ -8,24 +11,31 @@ local QA testing or in CI/CD test automation setups.
 
 :::
 
-#### Export Data to Console
+#### Prerequisite: Project Key from Memfault UI
 
-To test it out, call the `test_export` command added to your CLI above:
+A Project key will be needed in order to communicate with Memfault's web
+services. Go to [https://app.memfault.com/](https://app.memfault.com/), navigate
+to the project you want to use and select 'Settings'→'General'. The 'Project
+Key' listed is what you will want to use.
 
-```
-shell> reboot
-[00:00:01] INFO: System Booting!
-[00:00:02] INFO: Memfault Build ID: d8d6a047282f025fffa29fa767100f310bc40f80
-shell> trace
-# CLI command making a call to `memfault_data_export_dump_chunks`
-shell> export
-[00:00:10] INFO: MC:SFQCpwIBAwEHalRFU1RTRVJJQUwKbXRlc3Qtc29mdHdhcmUJajEuMC4wLXRlcw==:
-//...
-```
+#### Post Chunks To Memfault
 
-#### Upload data using Memfault CLI tool
+All data collected by Memfault can be exported as opaque packets called
+"chunks". To trigger an export, call the `test_export` command added to your
+device CLI or add a periodic call to `memfault_data_export_dump_chunks` in your
+code.
 
-Data can be exported locally in two ways:
+<details>
+<summary> With Desktop CLI Tool </summary>
+<br/>
+<PostChunksWithMemfaultCli/>
 
-- [via Console](/docs/embedded/export-chunks-over-console)
-- [via GDB](/docs/embedded/test-data-collection-with-gdb)
+</details>
+
+<details>
+<summary> With GDB </summary>
+<br/>
+
+<PostChunksWithGdb />
+
+</details>

--- a/docs/embedded/steps/post-data-with-gdb.mdx
+++ b/docs/embedded/steps/post-data-with-gdb.mdx
@@ -1,0 +1,67 @@
+### Prerequisites
+
+- You need to have a way to debug your product with GDB as part of your
+  development setup
+- The GDB version you are using needs to have the
+  [GDB Python API enabled](https://interrupt.memfault.com/blog/automate-debugging-with-gdb-python-api#getting-started-with-gdb-python).
+  (It's generally the default or there is a `-py` version of GDB which has it
+  included.)
+- You need to compile your firmware with debug symbol information (i.e `-g`
+  CFLAG)
+
+:::note
+
+Even if you are using other compilers such as ARMCC or IAR, you can load the ELF
+(.out, .elf) generated and debug it in GDB as well.
+
+:::
+
+### Launch GDB and connect debugger
+
+For example:
+
+```
+$ arm-none-eabi-gdb-py my_app.elf --ex="target remote :3333"
+(gdb)
+```
+
+### Load Memfault GDB script
+
+Copy and paste and run the following in gdb:
+
+```bash
+python exec('try:\n from urllib2 import urlopen\nexcept:\n from urllib.request import urlopen'); exec(urlopen('https://mflt.io/memfault-gdb-script').read())
+```
+
+:::tip
+
+Some GDB versions do not support Python scripting by default. If you see a
+message like "Python scripting is not supported in this copy of GDB", you might
+be able to run an alternative GDB binary with a -py suffix, for example
+arm-none-eabi-gdb-py.
+
+:::
+
+### Register Handler
+
+Copy the command below and paste it into GDB and hit enter. This will load a
+handler which automatically posts data to Memfault whenever
+`memfault_data_export_dump_chunks` is called.
+
+```bash
+memfault install_chunk_handler --verbose --project-key <YOUR_PROJECT_KEY>
+```
+
+### Try It Out!
+
+Now, every time `memfault_data_export_dump_chunks` is called, the data passed as
+a parameter to the function will automatically be posted to the Memfault cloud.
+You don't have to do anything else! You will see logs print in the gdb CLI as
+data is posted:
+
+```bash
+(gdb) Continuing.
+Successfully posted 45 bytes of chunk data
+Successfully posted 53 bytes of chunk data
+[...]
+```

--- a/docs/embedded/steps/post-data-with-memfault-cli.mdx
+++ b/docs/embedded/steps/post-data-with-memfault-cli.mdx
@@ -1,0 +1,52 @@
+### Install the Python Memfault CLI Tool
+
+The [Memfault Desktop CLI tool](/docs/ci/install-memfault-cli). tool is written
+in Python and published publicly in the
+[Python Package Index (pypi)](https://pypi.org/project/memfault-cli/).
+
+To install it, make sure you have a recent version of Python 3.x installed and
+run:
+
+```bash
+$ pip3 install memfault-cli
+$ memfault --help
+```
+
+### Save device logs to file
+
+Start your console with your favorite terminal client. Let the system run for a
+bit, periodically dumping data to the console by calling
+`memfault_data_export_dump_chunks`.
+
+You should see strings with the format: `MC:BASE64_ENCODED_CHUNK:` in the dump.
+
+:::note
+
+It's perfectly fine for other logs to be interleaved with the exported data.
+
+:::
+
+For example:
+
+```
+shell> reboot
+[00:00:01] INFO: System Booting!
+[00:00:02] INFO: Memfault Build ID: d8d6a047282f025fffa29fa767100f310bc40f80
+shell> trace
+# CLI command making a call to `memfault_data_export_dump_chunks`
+shell> export
+[00:00:10] INFO: MC:SFQCpwIBAwEHalRFU1RTRVJJQUwKbXRlc3Qtc29mdHdhcmUJajEuMC4wLXRlcw==:
+```
+
+Save the resulting logs to a file such as logs.txt
+
+### Post chunks from logs with Memfault CLI
+
+Run the desktop Memfault CLI tool on your saved log file. The utility will parse
+the logs, extract the Memfault data, and post it here for processing!
+
+```bash
+$ memfault --project-key ${YOUR_PROJECT_KEY} post-chunk --encoding sdk_data_export logs.txt
+Found 2 Chunks. Sending Data ...
+Success
+```

--- a/docs/embedded/test-data-collection-with-gdb.mdx
+++ b/docs/embedded/test-data-collection-with-gdb.mdx
@@ -1,8 +1,10 @@
 ---
 id: test-data-collection-with-gdb
-title: Using GDB to Test Data Collection
-sidebar_label: Using GDB to Test Data Collection
+title: Post Chunks with GDB
+sidebar_label: Extract Chunks with GDB
 ---
+
+import PostChunksWithGdb from "./steps/post-data-with-gdb.mdx";
 
 In the following tutorial we will walk through how to post chunks directly to
 the Memfault cloud using the `memfault` GDB commands included in the
@@ -12,90 +14,4 @@ This is typically most helpful as a quick way to test that data collection is
 working prior to implementing the
 [data transport path](data-from-firmware-to-cloud.mdx).
 
-## Prerequisites
-
-- You need to have a way to debug your product with GDB as part of your
-  development setup
-- The GDB version you are using needs to have the
-  [GDB Python API enabled](https://interrupt.memfault.com/blog/automate-debugging-with-gdb-python-api#getting-started-with-gdb-python).
-  (It's generally the default or there is a `-py` version of GDB which has it
-  included.)
-- You need to compile your firmware with debug symbol information (i.e `-g`
-  CFLAG)
-
-:::note
-
-Even if you are using other compilers such as ARMCC or IAR, you can load the ELF
-(.out, .elf) generated and debug it in GDB as well.
-
-:::
-
-## Loading the Memfault GDB Commands
-
-The Memfault Firmware SDK includes utilities implemented using the GDB Python
-API in the scripts directory. To load the scripts all you need to do is source
-it:
-
-```bash
-(gdb) source $MEMFAULT_SDK/scripts/memfault_gdb.py
-```
-
-You can then examine available commands by running `memfault --help`
-
-```bash
-(gdb) memfault --help
-Memfault GDB commands
-
-List of memfault subcommands:
-
-[...]
-memfault install_chunk_handler -- Installs a hook which sends chunks to the Memfault cloud chunk endpoint automagically
-[...]
-```
-
-## Registering GDB Handler to Send Data
-
-You will need a function in your project that gets called to send chunk data.
-The function can have any name and return value. The only requirement is that
-the last two parameters are a pointer to the data buffer and length of the
-buffer to send respectively. For example,
-
-```c
-#include "memfault/core/compiler.h"
-// We disable optimizations so parameters do not get stripped for this stub function
-MEMFAULT_NO_OPT
-void my_project_send_chunk_data(...any args..., void *buf, size_t buf_len) {
-  return;
-}
-```
-
-:::note
-
-Check out
-[`memfault_demo_drain_chunk_data()`](https://github.com/memfault/memfault-firmware-sdk/blob/master/components/demo/src/memfault_demo_cli_print_chunk.c#L139)
-in the SDK for a full working example.
-
-:::
-
-Once you have this in place, installing the handler to automatically post chunks
-is as easy as:
-
-```bash
-(gdb) memfault install_chunk_handler -pk <YOUR_PROJECT_KEY> --ch my_project_send_chunk_data
-```
-
-Now, every time `my_project_send_chunk_data` is called, the data passed as a
-parameter to the function will automatically be posted to the Memfault cloud.
-You don't have to do anything else!
-
-By default, the script will only out to gdb when an error occurs. If you would
-like to see a message print every time a chunk is posted you can use the
-`--verbose` option:
-
-```bash
-(gdb) memfault install_chunk_handler -pk <YOUR_PROJECT_KEY> --ch my_project_send_chunk_data --verbose
-(gdb) Continuing.
-Successfully posted 45 bytes of chunk data
-Successfully posted 53 bytes of chunk data
-[...]
-```
+<PostChunksWithGdb />


### PR DESCRIPTION
* Move bulk of gdb and cli based upload guides into MDX files so the steps can be dropped directly into the Cortex-M getting started guide
* Hide "memfault_data_export_dump_chunks()" override option behind toggle since 99% of folks should not need it
