### PR TITLE
Only perform prettier check on PRs from forked repo

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   prettier:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       - name: Checkout
@@ -24,3 +25,20 @@ jobs:
           prettier_options: --write **/*.{js,md,mdx}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # For pull requests generated from a fork, we run the prettier linter
+  # but leave it up to the user to fix locally since we would need extra
+  # permissions to be able to push a auto-fix commit to the forked repo
+  prettier-fork:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name != github.repository
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Prettify code
+        uses: creyD/prettier_action@v3.1
+        with:
+          # This part is also where you can pass other options, for example:
+          prettier_options: --write **/*.{js,md,mdx}
+          dry: true

--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ Start a local webserver that will pick up most changes without restarting:
 $ yarn start
 ```
 
+## Linter
+
+Code is linted with prettier. To fix up files to match format, run:
+
+```
+$ ./node_modules/prettier/bin-prettier.js --write /path/to/file.mdx
+```
+
 ## Content
 
 Add a new page to the docs:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $ yarn start
 Code is linted with prettier. To fix up files to match format, run:
 
 ```
-$ ./node_modules/prettier/bin-prettier.js --write /path/to/file.mdx
+$ ./node_modules/.bin/prettier --write path/to/file.mdx
 ```
 
 ## Content


### PR DESCRIPTION
The workflow we had configured for running prettier and auto-pushing a fix commit does not work when the pull request is generated against a forked repo for two reasons:
* "github.head_ref" is not a valid reference for the forked repo
* no clean way to push a auto-fix commit to the branch on the forked repo

I updated the lint work flow to be check-only for forked PRs so there isn't always a CI failure in this scenario and added some notes to the README about how to fix lint errors locally.