### PR TITLE
Rename blog to changelog, add redirect

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -121,12 +121,13 @@ module.exports = {
                     customCss: require.resolve("./src/css/custom.css"),
                 },
                 blog: {
-                    blogTitle: 'Memfault Changelog',
-                    blogDescription: 'The latest changes to the Memfault product and service',
+                    blogTitle: "Memfault Changelog",
+                    blogDescription:
+                        "The latest changes to the Memfault product and service",
                     blogSidebarCount: 10,
                     showReadingTime: false,
-                    routeBasePath: 'changelog',
-                }
+                    routeBasePath: "changelog",
+                },
             },
         ],
     ],

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -54,7 +54,7 @@ module.exports = {
                     target: "_blank",
                     rel: "noopener",
                 },
-                { to: "blog", label: "Changelog", position: "right" },
+                { to: "changelog", label: "Changelog", position: "right" },
             ],
         },
         footer: {
@@ -120,6 +120,13 @@ module.exports = {
                 theme: {
                     customCss: require.resolve("./src/css/custom.css"),
                 },
+                blog: {
+                    blogTitle: 'Memfault Changelog',
+                    blogDescription: 'The latest changes to the Memfault product and service',
+                    blogSidebarCount: 10,
+                    showReadingTime: false,
+                    routeBasePath: 'changelog',
+                }
             },
         ],
     ],

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,2 +1,5 @@
 /api    https://api-docs.memfault.com/
 /api/*  https://api-docs.memfault.com/:splat
+
+# Renamed blog to changelog
+/blog   /changelog

--- a/static/_redirects
+++ b/static/_redirects
@@ -3,3 +3,4 @@
 
 # Renamed blog to changelog
 /blog   /changelog
+/blog/* /changelog/:splat


### PR DESCRIPTION
We wanted the changelog to be called the changelog early on, but couldn't do it do to Docusaurus not having the ability to. It can as of a while ago, so let's do it!

Also made sure to add a redirect in Netlify to forward any old requests to the new URL.