### PR TITLE
MFLT-3337: Add Memfault Build ID to esp32 example project

### DIFF
--- a/docs/embedded/esp32-guide.mdx
+++ b/docs/embedded/esp32-guide.mdx
@@ -24,7 +24,7 @@ https://github.com/memfault/memfault-firmware-sdk.git
 
 ### Add Memfault SDK to the ESP-IDF CMake Build System
 
-In your top level CMakeLists.txt, you can register the Memfault esp-idf port as
+In your top level `CMakeLists.txt`, you can register the Memfault esp-idf port as
 a "component" by simply including `ports/esp_idf/memfault.cmake`:
 
 ```c
@@ -36,6 +36,37 @@ include(<PATH_TO_MEMFAULT_FIRMARE_SDK>/ports/esp_idf/memfault.cmake)
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(<YOUR_PROJECT>)
 ```
+### Add Memfault Build ID to the ESP-IDF CMake Build System
+
+You can also include Memfault build ID generation by adding a custom post-build step
+to your top level `CMakeLists.txt`.
+
+```c
+# CMakeLists.txt
+# [...]
+
+include(<PATH_TO_MEMFAULT_FIRMARE_SDK>/ports/esp_idf/memfault.cmake)
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(<YOUR_PROJECT>)
+
+add_custom_command(TARGET <YOUR_PROJECT>.elf
+  POST_BUILD
+  COMMAND python <PATH_TO_MEMFAULT_FIRMARE_SDK>/scripts/fw_build_id.py <YOUR_PROJECT>.elf)
+```
+
+The `fw_build_id.py` script adds a build ID that changes whenever the binary changes.
+You can use this build ID as part of your software version reported by
+`memfault_platform_get_device_info()`. See the demo app in
+`<PATH_TO_MEMFAULT_FIRMARE_SDK>/examples/esp32/apps/memfault_demo_app` for an
+example of how to use the build ID in your code.
+
+:::note
+
+`fw_build_id_py` depends on `pyelftools` so you may need to install it
+by running `pip install pyelftools`.
+
+:::
 
 ### Enable Coredump Collection in sdkconfig
 
@@ -96,7 +127,7 @@ $ touch ${PATH_INCLUDED_IN_BUILD}/memfault_trace_reason_user_config.def
 
 When a panic occurs, information is collected to uniquely identify the device
 and version of software running. Create a file, (i.e `memfault_platform_info.c`)
-and add it to your projects `main` component CMakeLists.txt.
+and add it to your projects `main` component `CMakeLists.txt`.
 
 Then implement the following function:
 

--- a/docs/embedded/esp32-guide.mdx
+++ b/docs/embedded/esp32-guide.mdx
@@ -24,8 +24,8 @@ https://github.com/memfault/memfault-firmware-sdk.git
 
 ### Add Memfault SDK to the ESP-IDF CMake Build System
 
-In your top level `CMakeLists.txt`, you can register the Memfault esp-idf port as
-a "component" by simply including `ports/esp_idf/memfault.cmake`:
+In your top level `CMakeLists.txt`, you can register the Memfault esp-idf port
+as a "component" by simply including `ports/esp_idf/memfault.cmake`:
 
 ```c
 # CMakeLists.txt
@@ -36,10 +36,11 @@ include(<PATH_TO_MEMFAULT_FIRMARE_SDK>/ports/esp_idf/memfault.cmake)
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(<YOUR_PROJECT>)
 ```
+
 ### Add Memfault Build ID to the ESP-IDF CMake Build System
 
-You can also include Memfault build ID generation by adding a custom post-build step
-to your top level `CMakeLists.txt`.
+You can also include Memfault build ID generation by adding a custom post-build
+step to your top level `CMakeLists.txt`.
 
 ```c
 # CMakeLists.txt
@@ -55,16 +56,16 @@ add_custom_command(TARGET <YOUR_PROJECT>.elf
   COMMAND python <PATH_TO_MEMFAULT_FIRMARE_SDK>/scripts/fw_build_id.py <YOUR_PROJECT>.elf)
 ```
 
-The `fw_build_id.py` script adds a build ID that changes whenever the binary changes.
-You can use this build ID as part of your software version reported by
+The `fw_build_id.py` script adds a build ID that changes whenever the binary
+changes. You can use this build ID as part of your software version reported by
 `memfault_platform_get_device_info()`. See the demo app in
 `<PATH_TO_MEMFAULT_FIRMARE_SDK>/examples/esp32/apps/memfault_demo_app` for an
 example of how to use the build ID in your code.
 
 :::note
 
-`fw_build_id_py` depends on `pyelftools` so you may need to install it
-by running `pip install pyelftools`.
+`fw_build_id_py` depends on `pyelftools` so you may need to install it by
+running `pip install pyelftools`.
 
 :::
 

--- a/docs/embedded/steps/clone-sdk.mdx
+++ b/docs/embedded/steps/clone-sdk.mdx
@@ -13,7 +13,7 @@ cd third_party/memfault
 # Add memfault repo as submodule, subtree, or copy in as source directly
 git submodule add https://github.com/memfault/memfault-firmware-sdk.git memfault-firmware-sdk
 
-cp memfault-firmware-sdk/ports/template/* .
+cp memfault-firmware-sdk/ports/templates/* .
 ```
 
 When you are done, you should have the following directory structure in your


### PR DESCRIPTION
 ### Summary

This is the document update portion to MFLT-3337 and describes
how to add build ID generation to an esp32 project.

 ### Test Plan

Verify that the additional step is clear and correct.