### PR TITLE
Add Algolia DocSearch

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -15,6 +15,10 @@ module.exports = {
     onBrokenMarkdownLinks: "throw",
     projectName: "memfault-firmware-sdk", // Usually your repo name.
     themeConfig: {
+        algolia: {
+            apiKey: "0ef3936beda1a4d57af35bd5917462b2",
+            indexName: "memfault",
+        },
         gtag: {
             trackingID: "G-R5JYJ06TDJ",
             anonymizeIP: true,


### PR DESCRIPTION
I applied for an API key here https://docsearch.algolia.com/apply/

After a week or so I received by email today. Integrating with
Docusaurus is super straightforward:
https://docusaurus.io/docs/search#using-algolia-docsearch

