### PR TITLE
MFLT-3548: Substitute YOUR_PROJECT_KEY in docs with actual key from URL params

### DIFF
--- a/docs/ci/authentication.mdx
+++ b/docs/ci/authentication.mdx
@@ -113,14 +113,14 @@ Every project member see the project's Project Key.
   <TabItem value="api">
 
 ```bash
-curl --header "Memfault-Project-Key: $PROJECT_KEY" ...
+curl --header "Memfault-Project-Key: $YOUR_PROJECT_KEY" ...
 ```
 
   </TabItem>
   <TabItem value="cli">
 
 ```bash
-memfault --project-key "$PROJECT_KEY" ...
+memfault --project-key "$YOUR_PROJECT_KEY" ...
 ```
 
   </TabItem>

--- a/docs/ci/install-memfault-cli.mdx
+++ b/docs/ci/install-memfault-cli.mdx
@@ -103,7 +103,7 @@ To use a Memfault Project key, pass `--project-key` after the `memfault`
 command.
 
 ```
-$ memfault --project-key ${PROJECT_KEY} ...
+$ memfault --project-key ${YOUR_PROJECT_KEY} ...
 ```
 
 ### Example Usage: Uploading Firmware Symbols

--- a/src/components/ProjectSetupDetailsContext.js
+++ b/src/components/ProjectSetupDetailsContext.js
@@ -26,6 +26,9 @@ export function ProjectSetupDetailsContextProvider({ children }) {
         operatingSystemOther: parsed.operating_system_other,
         primaryChip: parsed.primary_chip,
         primaryChipOther: parsed.primary_chip_other,
+
+        // Keys outside `ProjecSetupDetails`
+        projectKey: parsed.projectKey,
     });
 
     return (

--- a/src/theme/CodeBlock.js
+++ b/src/theme/CodeBlock.js
@@ -1,0 +1,45 @@
+import ProjectSetupDetailsContext from "@site/src/components/ProjectSetupDetailsContext";
+import DefaultCodeBlock from "@theme-original/CodeBlock";
+import React, { useContext, useMemo } from "react";
+
+function replaceSafe(
+    source /** unknown */,
+    replacements /** [search, target][] */
+) {
+    if (typeof source !== "string") return source;
+    return replace(source, replacements);
+}
+
+function replace(source /** string */, replacements /** [search, target][] */) {
+    let result = source;
+    replacements.forEach(([search, target]) => {
+        result = result.replaceAll(search, target);
+    });
+    return result;
+}
+
+/**
+ * The default code block, but aware of our ProjectSetupDetailsContext in case
+ * we have a project-specific strings that we can replace with actual values.
+ */
+export default function CodeBlock(props) {
+    const [{ projectKey }] = useContext(ProjectSetupDetailsContext);
+
+    const replacements = useMemo(() => {
+        return [
+            // Order matters: will be executed FIFO
+            ["<YOUR_PROJECT_KEY>", projectKey],
+            ["${YOUR_PROJECT_KEY}", projectKey],
+            ["$YOUR_PROJECT_KEY", projectKey],
+            ["YOUR_PROJECT_KEY", projectKey],
+        ].filter(([, target]) => !!target);
+    }, [projectKey]);
+
+    const children = useMemo(() => {
+        return Array.isArray(props.children)
+            ? props.children.map((child) => replaceSafe(child, replacements))
+            : replaceSafe(props.children, replacements);
+    }, [replacements, props.children]);
+
+    return <DefaultCodeBlock {...props}>{children}</DefaultCodeBlock>;
+}


### PR DESCRIPTION
## Summary

 I ran through some iterations of this: searching with XPath, feeding
 XPath results to a `MutationObserver`, substituting `textContent` and
 `innerHTML`... everything was bad, but I decided to read the Docusaurus
 docs a bit more and found this concept of "swizzling": basically
 ejecting Docusaurus theme components and substituting them with your
 own.

 [Docs on swizzling here](https://docusaurus.io/docs/using-themes#wrapping-theme-components).

 I basically "swizzled" the `CodeBlock` component and am running
 `.replace` on children that are strings.

 The different targets `<YOUR_PROJECT_KEY>`, `${YOUR_PROJECT_KEY}` are
 necessary because when the `projectKey` variable is _not_ present, the
 preexisting strings still need to make sense in their context. For
 example,  `${YOUR_PROJECT_KEY}` would be substituted by
 `THE_PROJECT_KEY` for a bash command to work, but if we don't have the
 actual value, then we still want to show the decorations, which may
 help with interpretation in shells.

 ## Test plan

 Manual:
 - Added `?projectKey=blabla` to several pages and checked that the
   substitution works
 - Checked that navigating to other pages still runs the substitution
   even if the param is no longer present (our context saves the values)