### PR TITLE
MFLT-3556: Mimic main website dir structure in /embed

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -66,8 +66,7 @@ module.exports = {
                 },
 
                 {
-                    to:
-                        "https://memfault.com/register?utm_campaign=Self%20Serve%20Launch&utm_source=Docs",
+                    to: "https://memfault.com/register?utm_campaign=Self%20Serve%20Launch&utm_source=Docs",
                     label: "API",
                     position: "left",
                     target: "_blank",
@@ -85,8 +84,7 @@ module.exports = {
                     items: [
                         {
                             label: "Sign Up",
-                            href:
-                                "https://memfault.com/register?utm_campaign=Self%20Serve%20Launch&utm_source=Docs",
+                            href: "https://memfault.com/register?utm_campaign=Self%20Serve%20Launch&utm_source=Docs",
                         },
                         {
                             label: "Log In",
@@ -103,8 +101,7 @@ module.exports = {
                     items: [
                         {
                             label: "Firmware SDK",
-                            href:
-                                "https://github.com/memfault/memfault-firmware-sdk",
+                            href: "https://github.com/memfault/memfault-firmware-sdk",
                         },
                         {
                             label: "Android Bort SDK",
@@ -147,8 +144,7 @@ module.exports = {
                         },
                         {
                             label: "YouTube",
-                            href:
-                                "https://www.youtube.com/channel/UCGHAOw3JpB6zOnwA27dlYcQ",
+                            href: "https://www.youtube.com/channel/UCGHAOw3JpB6zOnwA27dlYcQ",
                         },
                     ],
                 },

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -66,7 +66,8 @@ module.exports = {
                 },
 
                 {
-                    to: "https://memfault.com/register?utm_campaign=Self%20Serve%20Launch&utm_source=Docs",
+                    to:
+                        "https://memfault.com/register?utm_campaign=Self%20Serve%20Launch&utm_source=Docs",
                     label: "API",
                     position: "left",
                     target: "_blank",
@@ -84,7 +85,8 @@ module.exports = {
                     items: [
                         {
                             label: "Sign Up",
-                            href: "https://memfault.com/register?utm_campaign=Self%20Serve%20Launch&utm_source=Docs",
+                            href:
+                                "https://memfault.com/register?utm_campaign=Self%20Serve%20Launch&utm_source=Docs",
                         },
                         {
                             label: "Log In",
@@ -101,7 +103,8 @@ module.exports = {
                     items: [
                         {
                             label: "Firmware SDK",
-                            href: "https://github.com/memfault/memfault-firmware-sdk",
+                            href:
+                                "https://github.com/memfault/memfault-firmware-sdk",
                         },
                         {
                             label: "Android Bort SDK",
@@ -144,7 +147,8 @@ module.exports = {
                         },
                         {
                             label: "YouTube",
-                            href: "https://www.youtube.com/channel/UCGHAOw3JpB6zOnwA27dlYcQ",
+                            href:
+                                "https://www.youtube.com/channel/UCGHAOw3JpB6zOnwA27dlYcQ",
                         },
                     ],
                 },
@@ -185,9 +189,17 @@ module.exports = {
         [
             "@docusaurus/plugin-content-blog",
             {
-                id: "embed",
-                routeBasePath: "embed",
-                path: "./embed",
+                id: "embed-android",
+                routeBasePath: "embed/android",
+                path: "./embed/android",
+            },
+        ],
+        [
+            "@docusaurus/plugin-content-blog",
+            {
+                id: "embed-embedded",
+                routeBasePath: "embed/embedded",
+                path: "./embed/embedded",
             },
         ],
     ],

--- a/embed/android-getting-started-guide.mdx
+++ b/embed/android-getting-started-guide.mdx
@@ -1,5 +1,0 @@
-import Docs from "../docs/android/android-getting-started-guide.mdx";
-
-# Getting Started
-
-<Docs />

--- a/embed/android/android-getting-started-guide.mdx
+++ b/embed/android/android-getting-started-guide.mdx
@@ -1,0 +1,5 @@
+import Docs from "@site/docs/android/android-getting-started-guide.mdx";
+
+# Getting Started
+
+<Docs />

--- a/embed/arm-cortex-m-guide.mdx
+++ b/embed/arm-cortex-m-guide.mdx
@@ -1,5 +1,0 @@
-import Docs from "../docs/embedded/arm-cortex-m-guide.mdx";
-
-# ARM Cortex-M Integration Guide
-
-<Docs />

--- a/embed/embedded-self-serve.mdx
+++ b/embed/embedded-self-serve.mdx
@@ -1,5 +1,0 @@
-import Docs from "../docs/embedded/self-serve.mdx";
-
-# Embedded Integration Guide
-
-<Docs />

--- a/embed/embedded/arm-cortex-m-guide.mdx
+++ b/embed/embedded/arm-cortex-m-guide.mdx
@@ -1,0 +1,5 @@
+import Docs from "@site/docs/embedded/arm-cortex-m-guide.mdx";
+
+# ARM Cortex-M Integration Guide
+
+<Docs />

--- a/embed/embedded/embedded-self-serve.mdx
+++ b/embed/embedded/embedded-self-serve.mdx
@@ -1,0 +1,5 @@
+import Docs from "@site/docs/embedded/self-serve.mdx";
+
+# Embedded Integration Guide
+
+<Docs />

--- a/embed/embedded/esp32-guide.mdx
+++ b/embed/embedded/esp32-guide.mdx
@@ -1,0 +1,5 @@
+import Docs from "@site/docs/embedded/esp32-guide.mdx";
+
+# ESP32 ESP-IDF Integration Guide
+
+<Docs />

--- a/embed/embedded/esp8266-rtos-sdk-guide.mdx
+++ b/embed/embedded/esp8266-rtos-sdk-guide.mdx
@@ -1,0 +1,5 @@
+import Docs from "@site/docs/embedded/esp8266-rtos-sdk-guide.mdx";
+
+# ESP8266 RTOS Integration Guide
+
+<Docs />

--- a/embed/embedded/nrf-connect-sdk-guide.mdx
+++ b/embed/embedded/nrf-connect-sdk-guide.mdx
@@ -1,0 +1,5 @@
+import Docs from "@site/docs/embedded/nrf-connect-sdk-guide.mdx";
+
+# nRF Connect SDK Integration Guide
+
+<Docs />

--- a/embed/esp32-guide.mdx
+++ b/embed/esp32-guide.mdx
@@ -1,5 +1,0 @@
-import Docs from "../docs/embedded/esp32-guide.mdx";
-
-# ESP32 ESP-IDF Integration Guide
-
-<Docs />

--- a/embed/esp8266-rtos-sdk-guide.mdx
+++ b/embed/esp8266-rtos-sdk-guide.mdx
@@ -1,5 +1,0 @@
-import Docs from "../docs/embedded/esp8266-rtos-sdk-guide.mdx";
-
-# ESP8266 RTOS Integration Guide
-
-<Docs />

--- a/embed/nrf-connect-sdk-guide.mdx
+++ b/embed/nrf-connect-sdk-guide.mdx
@@ -1,5 +1,0 @@
-import Docs from "../docs/embedded/nrf-connect-sdk-guide.mdx";
-
-# nRF Connect SDK Integration Guide
-
-<Docs />

--- a/static/_redirects
+++ b/static/_redirects
@@ -4,3 +4,7 @@
 # Renamed blog to changelog
 /blog   /changelog
 /blog/* /changelog/:splat
+
+# Added namespacing to embed mode
+/embed/android-getting-started-guide /embed/android/android-getting-started-guide
+/embed/* /embed/embedded/:splat


### PR DESCRIPTION
I'm trying to reuse the links in the web application, which we currently
use as `src` to an `iframe`, to add a link so that users can read the
docs on `docs.memfault.com` as well.

It soon became apparent that having a different URL structure for
embed mode and normal mode was a bad idea.

The main website look like this:

- `/docs/embedded/*.mdx`
- `/docs/android/*.mdx`

However embed mode looked like this:

- `/embed/*.mdx`

So now they are both namespaced the same way, with `android` and
`embedded`.

I've also added redirects to our Netlify config so that this can be
deployed without orchestration.