### PR TITLE
Remove outdated integration step for nRF Connect SDK

### DIFF
--- a/docs/embedded/nrf-connect-sdk-guide.mdx
+++ b/docs/embedded/nrf-connect-sdk-guide.mdx
@@ -75,16 +75,6 @@ Initialized empty Git repository in modules/memfault-firmware-sdk/.git/
 --- memfault-firmware-sdk: fetching, need revision master
 ```
 
-### Add Memfault to Project's CMakeLists.txt
-
-Add the following **before the `find_package(...)`** line in your project's
-CMakeLists.txt
-
-```c
-list(APPEND ZEPHYR_EXTRA_MODULES $ENV{ZEPHYR_BASE}/../modules/memfault-firmware-sdk/ports/nrf-connect-sdk)
-# Note: A line like "find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})" should be below
-```
-
 ### Update Kconfig selections in prj.con
 
 Add the appropriate options to your systems `prj.conf`:
@@ -97,7 +87,7 @@ CONFIG_MEMFAULT=y
 # Add to pick up support for sending Memfault data over HTTP
 CONFIG_MEMFAULT_HTTP_ENABLE=y
 
-# NRF9160 only, uses modem to store root CA's
+# nRF9160 only, uses modem to store root CA's
 CONFIG_MEMFAULT_ROOT_CERT_STORAGE_NRF9160_MODEM=y
 ```
 
@@ -127,7 +117,7 @@ which will be used to communicate with Memfault's web services.
 
 In order to save traces, you will need to implement a dependency function that
 tells memfault version information. You can add this to the `main.c` for the app
-being built or a file of it's own.
+being built or a file of its own.
 
 ```c
 #include "memfault/core/platform/device_info.h"
@@ -143,7 +133,7 @@ void memfault_platform_get_device_info(sMemfaultDeviceInfo *info) {
 }
 ```
 
-### Implement NRF9160 Platform Dependencies
+### Implement nRF9160 Platform Dependencies
 
 Add the Project Key and install the Root CA's used by Memfault:
 


### PR DESCRIPTION
Got this during compilation:

```bash
(.venv)  ~/Development/memfault-nRF9160-relay => west build -b=qemu_x86_64 firmware
Including boilerplate (Zephyr base (cached)): /home/fausto/Development/memfault-nRF9160-relay/zephyr/cmake/app/boilerplate.cmake
[0/1] Re-running CMake...
-- Application: /home/fausto/Development/memfault-nRF9160-relay/firmware
-- Zephyr version: 2.4.99 (/home/fausto/Development/memfault-nRF9160-relay/zephyr)
-- Found west (found suitable version "0.11.0", minimum required is "0.7.1")
CMake Error at /home/fausto/Development/memfault-nRF9160-relay/zephyr/cmake/zephyr_module.cmake:61 (message):
  zephyr/../modules/memfault-firmware-sdk/ports/nrf-connect-sdk, given in
  ZEPHYR_EXTRA_MODULES, is not a valid zephyr module

Call Stack (most recent call first):
  /home/fausto/Development/memfault-nRF9160-relay/zephyr/cmake/app/boilerplate.cmake:183 (include)
  /home/fausto/Development/memfault-nRF9160-relay/zephyr/share/zephyr-package/cmake/ZephyrConfig.cmake:24 (include)
  /home/fausto/Development/memfault-nRF9160-relay/zephyr/share/zephyr-package/cmake/ZephyrConfig.cmake:40 (include_boilerplate)
  CMakeLists.txt:11 (find_package)

-- Configuring incomplete, errors occurred!
See also "/home/fausto/Development/memfault-nRF9160-relay/build/CMakeFiles/CMakeOutput.log".
See also "/home/fausto/Development/memfault-nRF9160-relay/build/CMakeFiles/CMakeError.log".
FAILED: build.ninja
/home/fausto/Development/memfault-nRF9160-relay/.venv/lib/python3.9/site-packages/cmake/data/bin/cmake --regenerate-during-build -S/home/fausto/Development/memfault-nRF9160-relay/firmware -B/home/fausto/Development/memfault-nRF9160-relay/build
ninja: error: rebuilding 'build.ninja': subcommand failed
FATAL ERROR: command exited with status 1: /home/fausto/Development/memfault-nRF9160-relay/.venv/bin/cmake --build /home/fausto/Development/memfault-nRF9160-relay/build
```

@chris pointed out to me that removing the lines would fix it. So I'm
removing it from the docs, too.