### PR TITLE
MFLT-3651: Fix missing quotes around project key in nRF guide

### DIFF
--- a/docs/embedded/nrf-connect-sdk-guide.mdx
+++ b/docs/embedded/nrf-connect-sdk-guide.mdx
@@ -128,11 +128,11 @@ CONFIG_MEMFAULT_ROOT_CERT_STORAGE_NRF9160_MODEM=y
 
 Add the appropriate options to your system's `prj.conf`:
 
-```bash {3,4}
+```bash {4}
 # Project-specific configuration settings
 
 CONFIG_MEMFAULT=y
-CONFIG_MEMFAULT_NCS_PROJECT_KEY=<YOUR_PROJECT_KEY>
+CONFIG_MEMFAULT_NCS_PROJECT_KEY="YOUR_PROJECT_KEY"
 ```
 
 You can find more details on the available options using `menuconfig`,


### PR DESCRIPTION
It used to render like so:

`CONFIG_MEMFAULT_NCS_PROJECT_KEY=blablabla`

Without quotes around it, it doesn't build. So I'm adding them. If the
change is confusing (why do the carets `<>` not render but the quotes
`""` do), please check out `src/theme/CodeBlock.js`:

https://github.com/memfault/memfault-docs/blob/master/src/theme/CodeBlock.js#L28-L36