### PR TITLE
Use ProjectAwareCreateAProject consistently

### DIFF
--- a/docs/android/android-getting-started-guide.mdx
+++ b/docs/android/android-getting-started-guide.mdx
@@ -4,10 +4,14 @@ title: Getting Started
 sidebar_label: Getting Started
 ---
 
+import ProjectAwareCreateAProject from "@site/src/components/ProjectAwareCreateAProject"
+
 This tutorial will cover integrating the [Bort SDK](android-bort.mdx) into a
 system running Android 10.
 
 ## Integration Steps
+
+<ProjectAwareCreateAProject />
 
 ### Clone Bort SDK
 

--- a/docs/android/android-getting-started-guide.mdx
+++ b/docs/android/android-getting-started-guide.mdx
@@ -4,7 +4,7 @@ title: Getting Started
 sidebar_label: Getting Started
 ---
 
-import ProjectAwareCreateAProject from "@site/src/components/ProjectAwareCreateAProject"
+import ProjectAwareCreateAProject from "@site/src/components/ProjectAwareCreateAProject";
 
 This tutorial will cover integrating the [Bort SDK](android-bort.mdx) into a
 system running Android 10.

--- a/docs/mcu/arm-cortex-m-guide.mdx
+++ b/docs/mcu/arm-cortex-m-guide.mdx
@@ -4,7 +4,7 @@ title: ARM Cortex-M Integration Guide
 sidebar_label: ARM Cortex-M
 ---
 
-import ProjectAwareCreateAProject from "@site/src/components/ProjectAwareCreateAProject"
+import ProjectAwareCreateAProject from "@site/src/components/ProjectAwareCreateAProject";
 
 import TryFlow from "@site/src/pages/_partials/_steps/_try-flow.mdx";
 import CloneSdk from "@site/src/pages/_partials/_steps/_clone-sdk.mdx";

--- a/docs/mcu/arm-cortex-m-guide.mdx
+++ b/docs/mcu/arm-cortex-m-guide.mdx
@@ -4,6 +4,8 @@ title: ARM Cortex-M Integration Guide
 sidebar_label: ARM Cortex-M
 ---
 
+import ProjectAwareCreateAProject from "@site/src/components/ProjectAwareCreateAProject"
+
 import TryFlow from "@site/src/pages/_partials/_steps/_try-flow.mdx";
 import CloneSdk from "@site/src/pages/_partials/_steps/_clone-sdk.mdx";
 import AddSources from "@site/src/pages/_partials/_steps/_add-sources.mdx";
@@ -13,7 +15,6 @@ import LoggingDependency from "@site/src/pages/_partials/_steps/_logging-depende
 import RtosPorts from "@site/src/pages/_partials/_steps/_rtos-ports.mdx";
 import CoredumpDependency from "@site/src/pages/_partials/_steps/_coredump-dependency.mdx";
 import RegisterAssert from "@site/src/pages/_partials/_steps/_register-assert.mdx";
-import CreateProjectKey from "@site/src/pages/_partials/_steps/_create-project-key.mdx";
 import UploadSymbolFile from "@site/src/pages/_partials/_steps/_upload-symbol-file.mdx";
 import DataTransferTroubleshooting from "@site/src/pages/_partials/_steps/_data-transfer-troubleshooting.mdx";
 import PostChunksLocally from "@site/src/pages/_partials/_steps/_post-chunks-locally.mdx";
@@ -38,6 +39,8 @@ or TI ARM Compiler.
 ### (Optionally) Collect a coredump capture using GDB
 
 <TryFlow />
+
+<ProjectAwareCreateAProject />
 
 ## Integration Steps
 

--- a/docs/mcu/esp32-guide.mdx
+++ b/docs/mcu/esp32-guide.mdx
@@ -4,6 +4,8 @@ title: ESP32 ESP-IDF Integration Guide
 sidebar_label: ESP32 ESP-IDF
 ---
 
+import ProjectAwareCreateAProject from "@site/src/components/ProjectAwareCreateAProject"
+
 This tutorial will go over integrating the
 [Memfault Firmware SDK](https://github.com/memfault/memfault-firmware-sdk) into
 a system that is using the
@@ -192,6 +194,8 @@ partition CSV file". Optionally, you can edit the sdkconfig file directly
 
 :::
 
+<ProjectAwareCreateAProject />
+
 ### Implement Changes for Your Project to Incorporate Memfault
 
 #### _Metrics and Trace Definitions_
@@ -233,18 +237,14 @@ void memfault_platform_get_device_info(sMemfaultDeviceInfo *info) {
 
 #### _g_mflt_http_client_config_
 
-An API key will need to be included in order to communicate with Memfault's web
-services. Go to https://app.memfault.com/, navigate to the project you want to
-use and select 'Settings'. Copy the 'Project Key' and replace
-`<YOUR API KEY HERE>` below and then add the following to
-`memfault_platform_port.c`.
+Copy your Project Key and add the following to `memfault_platform_port.c`:
 
 ```c
 // memfault_platform_port.c
 // [...]
 
 sMfltHttpClientConfig g_mflt_http_client_config = {
-  .api_key = "<YOUR API KEY HERE>",
+  .api_key = "<YOUR_PROJECT_KEY>",
 };
 ```
 

--- a/docs/mcu/esp32-guide.mdx
+++ b/docs/mcu/esp32-guide.mdx
@@ -4,7 +4,7 @@ title: ESP32 ESP-IDF Integration Guide
 sidebar_label: ESP32 ESP-IDF
 ---
 
-import ProjectAwareCreateAProject from "@site/src/components/ProjectAwareCreateAProject"
+import ProjectAwareCreateAProject from "@site/src/components/ProjectAwareCreateAProject";
 
 This tutorial will go over integrating the
 [Memfault Firmware SDK](https://github.com/memfault/memfault-firmware-sdk) into

--- a/docs/mcu/esp8266-rtos-sdk-guide.mdx
+++ b/docs/mcu/esp8266-rtos-sdk-guide.mdx
@@ -35,7 +35,7 @@ your system!
 
 ## Integration Steps
 
-:::caution
+:::important
 
 This tutorial assumes you have a working
 [ESP8266 RTOS SDK environment](https://docs.espressif.com/projects/esp8266-rtos-sdk/en/latest/get-started/index.html)

--- a/docs/mcu/nrf-connect-sdk-guide.mdx
+++ b/docs/mcu/nrf-connect-sdk-guide.mdx
@@ -51,6 +51,8 @@ etc)
 
 :::
 
+<ProjectAwareCreateAProject />
+
 ### Include memfault-firmware-sdk in the build
 
 <Tabs
@@ -105,8 +107,6 @@ running `west update`. By default, it is downloaded to
 
   </TabItem>
 </Tabs>
-
-<ProjectAwareCreateAProject />
 
 ### Update Kconfig selections in prj.con {#kconfig-section}
 

--- a/docs/mcu/self-serve-local-testing.mdx
+++ b/docs/mcu/self-serve-local-testing.mdx
@@ -4,7 +4,6 @@ title: Local Testing
 sidebar_label: Local Testing
 ---
 
-import CreateProjectKey from "@site/src/pages/_partials/_steps/_create-project-key.mdx";
 import UploadSymbolFile from "@site/src/pages/_partials/_steps/_upload-symbol-file.mdx";
 import DataTransferTroubleshooting from "@site/src/pages/_partials/_steps/_data-transfer-troubleshooting.mdx";
 import PostChunksLocally from "@site/src/pages/_partials/_steps/_post-chunks-locally.mdx";

--- a/src/pages/_partials/_steps/_create-project-key.mdx
+++ b/src/pages/_partials/_steps/_create-project-key.mdx
@@ -1,5 +1,0 @@
-Go to https://app.memfault.com/ and from the "Select A Project" dropdown, click
-on "Create Project" to setup your first project such as "smart-sink-dev".
-
-Then navigate to "Settings" -> "General", where you can find the "Project Key"
-which will be used to communicate with Memfault's web services.


### PR DESCRIPTION
Prefer `ProjectAwareCreateAProject` instead of special text for each guide:

https://github.com/memfault/memfault-docs/blob/master/src/components/ProjectAwareCreateAProject.js

Also, add `ProjectAwareCreateAProject` to some existing guides that didn't mention where to get a project key from.