### PR TITLE
Fix /embed/embedded -> /embed/mcu redirects

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -5,9 +5,6 @@
 /blog   /changelog
 /blog/* /changelog/:splat
 
-# Added namespacing to embed mode
-/embed/android-getting-started-guide /embed/android/android-getting-started-guide
-/embed/* /embed/mcu/:splat
-
 # Renamed embedded to mcu
-/docs/embedded/* /docs/mcu/*
+/embed/embedded/* /embed/mcu/:splat
+/docs/embedded/* /docs/mcu/:splat


### PR DESCRIPTION
Sample URLs from our integration guide:

- [WORKS] https://docs.memfault.com/embed/android/android-getting-started-guide
- [BROKEN] https://docs.memfault.com/embed/embedded/embedded-self-serve
- [BROKEN] https://docs.memfault.com/embed/embedded/embedded-self-serve

After https://github.com/memfault/memfault-docs/pull/61, the namespacing
redirect is no longer necessary.

The new redirects should match the actual routes being used:

```
/embed/embedded/* /embed/mcu/:splat
/docs/embedded/* /docs/mcu/:splat
```