### PR TITLE
Prompt a yarn cache bust by upgrading prettier

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -93,8 +93,8 @@ section.features_src-pages- {
 }
 
 /**
- * Hide the "See all ## results" link at the bottom of the search widget. See
- * the issue linked below for more context.
+ * Hide the "See all ## results" link at the bottom of the search widget.
+ * See the issue linked below for more context.
  *
  * The nested class selector is merely here for specificity. Unfortunately,
  * Docusaurus outputs its own CSS after ours.

--- a/yarn.lock
+++ b/yarn.lock
@@ -10009,9 +10009,9 @@ prepend-http@^2.0.0:
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
 
 prettier@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
-  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.2.tgz#ef280a05ec253712e486233db5c6f23441e7342d"
+  integrity sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==
 
 pretty-error@^2.1.1:
   version "2.1.2"


### PR DESCRIPTION
The DocSearch deployment succeeded (as per Netlify logs) but I can't see
the search widget. I'm wondering whether this can be fixed by rebuilding
the application. The widget not showing up was something that happened a
couple of times locally for me, and busting the cache worked to fix it.