### PR TITLE
MFLT-3835: Restore dark mode in the docs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -23,6 +23,9 @@ module.exports = {
             trackingID: "G-R5JYJ06TDJ",
             anonymizeIP: true,
         },
+        prism: {
+            theme: require("prism-react-renderer/themes/oceanicNext"),
+        },
         navbar: {
             title: "Memfault Docs",
             logo: {

--- a/src/components/EmbedMode.js
+++ b/src/components/EmbedMode.js
@@ -1,5 +1,5 @@
 import Head from "@docusaurus/Head";
-import React, { useMemo } from "react";
+import React, { useMemo, useEffect } from "react";
 import { useLocation } from "react-router";
 
 const EmbedModeContext = React.createContext({ enabled: false, settings: {} });
@@ -18,10 +18,46 @@ export function EmbedModeProvider({ children }) {
                         <meta name="robots" content="noindex" />
                     </Head>
                     <div className="embed-mode">{children}</div>
+                    <ForceColorMode mode="light" />
                 </>
             ) : (
                 children
             )}
         </EmbedModeContext.Provider>
     );
+}
+
+function setColorMode(mode) {
+    const html = document.querySelector("html");
+    if (html.dataset.theme !== mode) {
+        html.dataset.theme = mode;
+    }
+}
+
+function ForceColorMode({ mode }) {
+    // It's possible to also use useThemeContext from Docusaurus, but I haven't
+    // managed to set it up without it causing infinite loops, for some reason.
+    useEffect(() => {
+        if (
+            typeof window === "undefined" ||
+            typeof MutationObserver === "undefined"
+        )
+            return () => undefined;
+
+        setColorMode(mode); // Avoids or shortens flicker
+
+        const observer = new MutationObserver(() => {
+            setColorMode(mode);
+        });
+
+        observer.observe(document.querySelector("html"), {
+            childList: false,
+            attributes: "true",
+            attributeFilter: ["data-theme"],
+        });
+
+        return observer.disconnect;
+    }, []);
+
+    return null;
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -33,18 +33,14 @@
     --ifm-color-primary-lighter: rgb(102, 212, 189);
     --ifm-color-primary-lightest: rgb(146, 224, 208);
     --ifm-color-warning: #ff8100; /* white text on yellow background is hard to read */
-    --ifm-footer-background-color: #131e32;
 }
 
 .docusaurus-highlight-code-line {
-    background-color: rgb(72, 77, 91);
-    display: block;
+    /* A translucent white background on top of the background works with any background */
+    background-color: rgba(255, 255, 255, 0.07);
+    /* Make the line highlight reach the end of the container */
     margin: 0 calc(-1 * var(--ifm-pre-padding));
     padding: 0 var(--ifm-pre-padding);
-}
-
-html[data-theme="dark"] .footer--dark {
-    --ifm-footer-background-color: #131e32;
 }
 
 html[data-theme="dark"] .hero--primary {
@@ -55,6 +51,11 @@ html[data-theme="dark"] .hero--primary {
 html[data-theme="light"]
     .button.hero__get-started-button:not(.button--active):not(:hover) {
     color: #ffffff;
+}
+
+.admonition code {
+    color: var(--ifm-alert-color);
+    background-color: rgba(0, 0, 0, 0.25);
 }
 
 /* TODO remove this margin when the home page images are inserted */
@@ -80,8 +81,4 @@ section.features_src-pages- {
     margin: 0;
     max-width: 100%;
 }
-
-.admonition code {
-    color: var(--ifm-alert-color);
-    background-color: rgba(0, 0, 0, 0.25);
-}
+/* End embed mode rules */

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -53,6 +53,40 @@ html[data-theme="light"]
     color: #ffffff;
 }
 
+html[data-theme="light"] .DocSearch {
+    --docsearch-primary-color: var(--ifm-color-primary);
+    --docsearch-text-color: var(--ifm-font-color-base);
+    --docsearch-muted-color: var(--ifm-color-secondary-darkest);
+    --docsearch-container-background: rgba(94, 100, 112, 0.7); /* Modal */
+    --docsearch-modal-background: var(
+        --ifm-color-secondary-lighter
+    ); /* Search box */
+    --docsearch-searchbox-background: var(--ifm-color-secondary);
+    --docsearch-searchbox-focus-background: var(--ifm-color-white); /* Hit */
+    --docsearch-hit-color: var(--ifm-font-color-base);
+    --docsearch-hit-active-color: var(--ifm-color-white);
+    --docsearch-hit-background: var(--ifm-color-white); /* Footer */
+    --docsearch-footer-background: var(--ifm-color-white);
+}
+
+html[data-theme="dark"] .DocSearch {
+    --docsearch-text-color: var(--ifm-font-color-base);
+    --docsearch-muted-color: var(--ifm-color-secondary-darkest);
+    --docsearch-container-background: rgba(47, 55, 69, 0.7); /* Modal */
+    --docsearch-modal-background: var(--ifm-background-color); /* Search box */
+    --docsearch-searchbox-background: var(--ifm-background-color);
+    --docsearch-searchbox-focus-background: var(--ifm-color-black); /* Hit */
+    --docsearch-hit-color: var(--ifm-font-color-base);
+    --docsearch-hit-active-color: var(--ifm-color-white);
+    --docsearch-hit-background: var(--ifm-color-emphasis-100); /* Footer */
+    --docsearch-footer-background: var(--ifm-background-surface-color);
+    --docsearch-key-gradient: linear-gradient(
+        -26.5deg,
+        var(--ifm-color-emphasis-200) 0%,
+        var(--ifm-color-emphasis-100) 100%
+    );
+}
+
 .admonition code {
     color: var(--ifm-alert-color);
     background-color: rgba(0, 0, 0, 0.25);

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -25,7 +25,7 @@
         Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif, BlinkMacSystemFont,
         "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji",
         "Segoe UI Emoji", "Segoe UI Symbol";
-    --ifm-color-primary: #25c8d4;
+    --ifm-color-primary: #49b4a7;
     --ifm-color-primary-dark: rgb(33, 175, 144);
     --ifm-color-primary-darker: rgb(31, 165, 136);
     --ifm-color-primary-darkest: rgb(26, 136, 112);
@@ -33,6 +33,7 @@
     --ifm-color-primary-lighter: rgb(102, 212, 189);
     --ifm-color-primary-lightest: rgb(146, 224, 208);
     --ifm-color-warning: #ff8100; /* white text on yellow background is hard to read */
+    --ifm-footer-background-color: #131e32;
 }
 
 .docusaurus-highlight-code-line {
@@ -42,14 +43,18 @@
     padding: 0 var(--ifm-pre-padding);
 }
 
-.hero
-    .button.button--secondary.button--outline:not(.button--active):not(:hover) {
-    color: var(--ifm-hero-text-color);
+html[data-theme="dark"] .footer--dark {
+    --ifm-footer-background-color: #131e32;
 }
 
-.footer.footer--dark {
-    background-color: #011246;
-    color: #677190;
+html[data-theme="dark"] .hero--primary {
+    background-color: var(--ifm-background-color);
+    color: #ffffff;
+}
+
+html[data-theme="light"]
+    .button.hero__get-started-button:not(.button--active):not(:hover) {
+    color: #ffffff;
 }
 
 /* TODO remove this margin when the home page images are inserted */
@@ -57,18 +62,7 @@ section.features_src-pages- {
     margin-top: 20px;
 }
 
-/* TODO these rules hide the dark mode flipper.  remove them when styling
-   of the /api pages is fixed for dark mode. */
-.navbar .react-toggle-track,
-.navbar .react-toggle-thumb,
-.navbar .input {
-    display: none;
-}
-.navbar .navbar__items--right .navbar__link {
-    padding-right: 5px;
-}
-/* end of rules to hide dark mode flippper */
-
+/* Begin embed mode rules: hide stuff that doesn't need to be in iframes */
 .embed-mode .navbar,
 .embed-mode .footer,
 .embed-mode .pagination-nav,

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -96,7 +96,7 @@ function Home() {
                     <div className={styles.buttons}>
                         <Link
                             className={classnames(
-                                "button button--outline button--secondary button--lg",
+                                "button button--outline button--secondary button--lg hero__get-started-button",
                                 styles.getStarted
                             )}
                             to={useBaseUrl("docs/mcu/introduction")}


### PR DESCRIPTION
## Summary

 There were some rules disabling the light/dark theme switch that comes
 with Docusaurus. I removed them, and discovered that the docs look
 pretty terrible in dark mode.

 This is a WIP attempt at getting dark mode to look OK in the docs, and
 at the same time make the color scheme a bit closer to what our website
 looks like.

 Things that still look bad:

 - ~Code blocks in dark mode (they're full of inline styles and I don't
   know where they come from)~ **Fixed!** Swapped the theme for `oceanic-next` and it looks great.
 - Generally, screenshots of the app in light mode look
   bad/jarring/eye-burning in dark mode
 - ~The landing page isn't great. I think I need to swap the footer color
   for the grey in the main body~ **Fixed!** Stole a color from our website.
 - ~The Algolia search widget has a blueish shade that doesn't match our
   green from the website~ **Fixed!** It was easy to theme the widget.

 ## Test Plan

 Does it look OK?