### PR TITLE
Remove reference to esp-idf v4.4.x

### DIFF
--- a/docs/mcu/esp32-guide.mdx
+++ b/docs/mcu/esp32-guide.mdx
@@ -15,12 +15,6 @@ not, the official getting started guide is a great resource!
 
 The integration works for both ESP-IDF 3.x and 4.x releases.
 
-:::note
-
-ESP-IDF v4.4.x requires an extra step.
-
-:::
-
 ### Clone Memfault SDK
 
 Using a [Git](https://git-scm.com/) client, clone the `memfault-firmware-sdk`


### PR DESCRIPTION
I'm not sure what extra step is being referred to; there also doesn't
appear to be a v4.4.x release of ESP-IDF, the latest I see is v4.3.

Remove the note.