### PR TITLE
Update broken links to nRF Connect Docs

### DIFF
--- a/docs/mcu/nrf-connect-sdk-guide.mdx
+++ b/docs/mcu/nrf-connect-sdk-guide.mdx
@@ -19,10 +19,10 @@ releases ranging from v1.4.0 up to v1.6.0.
 
 nRF Connect SDK v1.6.0 has built-in support for the Memfault Firmware SDK on
 nRF9160-based targets. Nordic Semiconductor has released some
-[excellent documentation](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/include/memfault_ncs.html)
+[excellent documentation](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/1.6.1/nrf/include/memfault_ncs.html)
 on how to integrate Memfault in your existing nRF Connect SDK project, together
 with a
-[sample integration project](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/samples/nrf9160/memfault/README.html#memfault-sample).
+[sample integration project](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/1.6.1/nrf/samples/nrf9160/memfault/README.html#memfault-sample).
 We recommend following both this documentation page as well as Nordic's.
 
 :::
@@ -47,7 +47,7 @@ your system!
 :::important
 
 This tutorial assumes you have a working
-[nRF Connect SDK Environment](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/getting_started.html#getting-started)
+[nRF Connect SDK Environment](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/1.6.1/nrf/getting_started.html#getting-started)
 and are able to flash a board supported by the SDK (i.e nRF91, nRF53, nRF52,
 etc)
 
@@ -288,7 +288,7 @@ $ touch config/memfault_metrics_heartbeat_config.def
 ```
 
 See the
-[nRF Connect Docs](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/include/memfault_ncs.html#configuration-files)
+[nRF Connect Docs](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/1.6.1/nrf/include/memfault_ncs.html#configuration-files)
 for more information.
 
 ### Generate Some Trace Events
@@ -466,6 +466,6 @@ to help!
 
 ## Useful links
 
-- [nRF Connect SDK documentation on built-in Memfault Firmware SDK integration](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/include/memfault_ncs.html)
+- [nRF Connect SDK documentation on built-in Memfault Firmware SDK integration](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/1.6.1/nrf/include/memfault_ncs.html)
   (starting from v.1.6.0).
-- [Nordic's sample Memfault Firmware SDK integration project](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/samples/nrf9160/memfault/README.html#memfault-sample).
+- [Nordic's sample Memfault Firmware SDK integration project](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/1.6.1/nrf/samples/nrf9160/memfault/README.html#memfault-sample).


### PR DESCRIPTION
The new link on `latest` to the memfault page is:
> https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/others/memfault_ncs.html#configuration-files

Which used to be:
> https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/include/memfault_ncs.html#configuration-files

This patch pins the links to the 1.6.1 version of the docs.