### PR TITLE
Add note about runtime disabling Memfault

### DIFF
--- a/docs/mcu/runtime-control.mdx
+++ b/docs/mcu/runtime-control.mdx
@@ -1,0 +1,67 @@
+---
+id: runtime-control
+title: Enabling and Disabling Memfault at Runtime
+sidebar_label: Runtime Control
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+This guide covers how to enable and disable Memfault at runtime (vs. at
+compile-time). This can vary widely depending on the particular integration
+strategy or system, so some examples are provided after the general information
+section.
+
+## Overall Strategy
+
+The recommended way to deactivate Memfault at runtime is to turn off the
+mechanism used to send Memfault chunks to the cloud.
+
+This allows you to pull Memfault diagnostic data off of devices manually if you
+have a direct connection to the device such as JTAG, serial, etc or re-enable
+dynamically and get historical context immediately.
+
+To accomplish this one needs to add a check around the system the packetizer
+APIs are used (see [here](/docs/mcu/data-from-firmware-to-the-cloud) for
+details).
+
+For example, you might use a variable to control whether sending is attempted
+(perhaps loaded from NVRAM settings database on device):
+
+```c
+#include <stdbool.h>
+
+static bool enable_memfault_upload = false;
+
+...
+void periodic_task(void) {
+  if (s_enable_memfault_upload) {
+    try_send_memfault_data();
+  }
+}
+```
+
+Note that this only disables the sending of Memfault data. All the collection
+mechanisms will still be enabled as usual (eg coredump saving, metrics, etc).
+
+## Zephyr (including nRF Connect SDK)
+
+This will depend on if `CONFIG_MEMFAULT_HTTP_PERIODIC_UPLOAD=y` is used.
+
+### CONFIG_MEMFAULT_HTTP_PERIODIC_UPLOAD=y
+
+These instructions are based on
+[the example in the nrf-connect SDK](https://github.com/nrfconnect/sdk-nrf/tree/master/samples/nrf9160/memfault):
+
+1. disable `MEMFAULT_HTTP_PERIODIC_UPLOAD` in Kconfig (i.e. in your prj.conf)
+2. Add this content to one of your source files (eg main or wherever makes
+   sense):
+   https://github.com/memfault/memfault-firmware-sdk/blob/4ec7a0c61f9c8c94c74c0d31ca0e76c190010bfc/ports/zephyr/common/memfault_http_periodic_upload.c
+3. use `k_timer_start` and `k_timer_stop` on that timer to control the automatic
+   posting of data
+
+### CONFIG_MEMFAULT_HTTP_PERIODIC_UPLOAD=n
+
+If `CONFIG_MEMFAULT_HTTP_PERIODIC_UPLOAD=n` (default), you'll need to follow the
+[overalll strategy](#overall-strategy) explained above when disabling the chunks
+sending.


### PR DESCRIPTION
Had a customer ask about this; keep it off the side bar but make it
public in case we need to pass this info to other customers.