### PR TITLE
Fix some broken links

### DIFF
--- a/docs/android/android-getting-started-guide.mdx
+++ b/docs/android/android-getting-started-guide.mdx
@@ -6,8 +6,8 @@ sidebar_label: Getting Started
 
 import ProjectAwareCreateAProject from "@site/src/components/ProjectAwareCreateAProject";
 
-This tutorial will cover integrating the [Bort SDK](android-bort) into a
-system running Android 10. For other versions, simply change the input to the
+This tutorial will cover integrating the [Bort SDK](android-bort) into a system
+running Android 10. For other versions, simply change the input to the
 `patch-aosp` below to the correct version.
 
 ## Integration Steps

--- a/docs/android/android-getting-started-guide.mdx
+++ b/docs/android/android-getting-started-guide.mdx
@@ -6,7 +6,7 @@ sidebar_label: Getting Started
 
 import ProjectAwareCreateAProject from "@site/src/components/ProjectAwareCreateAProject";
 
-This tutorial will cover integrating the [Bort SDK](android-bort.mdx) into a
+This tutorial will cover integrating the [Bort SDK](android-bort) into a
 system running Android 10. For other versions, simply change the input to the
 `patch-aosp` below to the correct version.
 
@@ -44,7 +44,7 @@ necessary. We suggest appending `bort` to your
 For example, `com.mycorp.bort`.
 
 The OTA application ID must also be set, if using the
-[OTA Update Client](android-ota-update-client.mdx). For example,
+[OTA Update Client](android-ota-update-client). For example,
 `com.mycorp.bort.ota`.
 
 Patch the default application ID with your own:
@@ -157,7 +157,7 @@ storePassword=mySecretStorePassword
 ### Create a keystore for the OTA Update Client app
 
 **This step is only required if using the
-[OTA Update Client](android-ota-update-client.mdx)**
+[OTA Update Client](android-ota-update-client)**
 
 If using the OTA Update Client, a separate keystore should be created, following
 the same steps as for the Bort app.

--- a/docs/android/introduction.mdx
+++ b/docs/android/introduction.mdx
@@ -35,7 +35,7 @@ Android? [Let us know!](mailto:hello@memfault.com)
   <img width="800" src="/binary-assets/android-bort-architecture.svg" />
 </p>
 
-Memfault provides the [Bort SDK](android-bort.mdx), an open source, customizable
+Memfault provides the [Bort SDK](android/android-bort.mdx), an open source, customizable
 SDK that can be easily integrated into your Android build.
 
 Once integrated, it can collect detailed diagnostics from the entire operating
@@ -54,7 +54,7 @@ _Caliper_ system, or bug reports, or both, depending on how the _Bort_
 application is configured.
 
 For a detailed integration guide, see the
-[Getting Started Guide](android-getting-started-guide.mdx).
+[Getting Started Guide](android-getting-started-guide).
 
 To symbolicate native and ANR traces, as well as deobfuscate android traces,
 Memfault provides a CLI tool that can be integrated into your build system to

--- a/docs/android/introduction.mdx
+++ b/docs/android/introduction.mdx
@@ -35,8 +35,8 @@ Android? [Let us know!](mailto:hello@memfault.com)
   <img width="800" src="/binary-assets/android-bort-architecture.svg" />
 </p>
 
-Memfault provides the [Bort SDK](android/android-bort.mdx), an open source, customizable
-SDK that can be easily integrated into your Android build.
+Memfault provides the [Bort SDK](android/android-bort.mdx), an open source,
+customizable SDK that can be easily integrated into your Android build.
 
 Once integrated, it can collect detailed diagnostics from the entire operating
 system to provide diagnostics and telemetry on everything from low-level

--- a/docs/linux/introduction.mdx
+++ b/docs/linux/introduction.mdx
@@ -11,7 +11,7 @@ Memfault's support for embedded Linux devices is a work-in-progress.
 
 OTA / Release Management is currently fully supported through an off-the-shelve
 integration with the SWUpdate agent. Read more about it in the
-[OTA / Release Management guide](linux/linux-releases-guide.mdx).
+[OTA / Release Management guide](linux-releases-integration-guide).
 
 For other Memfault features, such as
 [Reboot Reason Tracking](/docs/mcu/reboot-reason-tracking),


### PR DESCRIPTION
Docusaurus gets really confused when trying to find dead links.
It says it uses the ID for these links, but I can't actually
confirm that. Anywho, fix the links that I found that were broken.