### PR TITLE
Small note about allocation shim in Zephyr

### DIFF
--- a/docs/mcu/heap-stats.mdx
+++ b/docs/mcu/heap-stats.mdx
@@ -62,6 +62,13 @@ To enable the wrappers, add these flags to the linker command flags:
 -Wl,--wrap=malloc,--wrap=free
 ```
 
+For Zephyr based projects, that can be added to the appropriate `CMakeLists.txt`
+file as:
+
+```cmake
+zephyr_ld_options("-Wl,--wrap=malloc,--wrap=free")
+```
+
   </TabItem>
   <TabItem value="freertos">
 For systems using the Memfault FreeRTOS port, and a  FreeRTOS heap


### PR DESCRIPTION
Eventually we should have a port that will do this automatically, but
for now include a note in the instructions here.