### PR TITLE
Fix URLs when current page includes trailing `/`

### DIFF
--- a/docs/android/android-builtin-metrics.mdx
+++ b/docs/android/android-builtin-metrics.mdx
@@ -10,7 +10,8 @@ from Android devices.
 Some are automatically collected, and some require configuration in the Memfault
 dashboard.
 
-To record custom metrics, see the [Reporting APIs](android-custom-metrics).
+To record custom metrics, see the
+[Reporting APIs](/docs/android/android-custom-metrics).
 
 :::info
 

--- a/docs/android/android-custom-metrics.mdx
+++ b/docs/android/android-custom-metrics.mdx
@@ -38,7 +38,7 @@ the `reporting-lib` library. This library reports metrics to the
 to be started for every value recorded).
 
 To add the library,
-[follow these instructions](custom-events#add-the-reporting-lib-library).
+[follow these instructions](/docs/android/custom-events#add-the-reporting-lib-library).
 
 A C/C++ library will be added in a future release.
 

--- a/docs/android/android-ota-update-client.mdx
+++ b/docs/android/android-ota-update-client.mdx
@@ -5,8 +5,9 @@ sidebar_label: OTA Update Client
 ---
 
 The Bort SDK includes a full OTA Update Client since version 3.7.0, which uses
-the [Memfault Android OTA service](android-releases-integration-guide) to manage
-the OTA update process. This supports:
+the
+[Memfault Android OTA service](/docs/android/android-releases-integration-guide)
+to manage the OTA update process. This supports:
 
 - [`RecoverySystem`-based updates](https://source.android.com/devices/tech/ota/nonab).
 - [Update Engine-based updates](https://source.android.com/devices/tech/ota/ab#life-of-an-a-b-update)
@@ -81,11 +82,11 @@ running, in order to function correctly.
 ## Enable OTA Update Client
 
 Ensure that the Bort OTA application ID is set (see
-[Patch the SDK](android-getting-started-guide#patch-the-sdk) or manually update
-`BORT_OTA_APPLICATION_ID` in `bort.properties`).
+[Patch the SDK](/docs/android/android-getting-started-guide#patch-the-sdk) or
+manually update `BORT_OTA_APPLICATION_ID` in `bort.properties`).
 
 The OTA app also needs to be configured with a keystore. See
-[Create a keystore for the OTA Update Client app](android-getting-started-guide#create-a-keystore-for-the-bort-ota-update-client-app).
+[Create a keystore for the OTA Update Client app](/docs/android/android-getting-started-guide#create-a-keystore-for-the-bort-ota-update-client-app).
 
 Once the OTA application is configured, setting the `TARGET_USES_MFLT_OTA`
 environment variable will include it in the system image. e.g.
@@ -96,7 +97,7 @@ export TARGET_USES_MFLT_OTA=1
 
 After building and installing the system image, the Memfault OTA app will be
 active. A Release can now be
-[activated in the Cohort](android-releases-integration-guide#activate-the-release)
+[activated in the Cohort](/docs/android/android-releases-integration-guide#activate-the-release)
 containing this device.
 
 ## Customizing the OTA Update Client

--- a/docs/android/android-releases-guide.mdx
+++ b/docs/android/android-releases-guide.mdx
@@ -7,7 +7,8 @@ sidebar_label: OTA Management
 :::info
 
 The Bort SDK includes a full OTA update client, from version 3.7.0 onwards. See
-[Bort OTA client](android-ota-update-client) below for more information.
+[Bort OTA client](/docs/android/android-ota-update-client) below for more
+information.
 
 :::
 
@@ -234,7 +235,8 @@ Release.
 
 :::info
 
-The [OTA Update Client](android-ota-update-client) manages this process!
+The [OTA Update Client](/docs/android/android-ota-update-client) manages this
+process!
 
 :::
 

--- a/docs/android/introduction.mdx
+++ b/docs/android/introduction.mdx
@@ -63,6 +63,6 @@ upload the required symbols and mappings, respectively. See
 for more information.
 
 The _Bort_ SDK contains
-[built-in support for collecting many Android system metrics](android-builtin-metrics).
+[built-in support for collecting many Android system metrics](/docs/android/android-builtin-metrics).
 To track additional or custom metrics on your platform, see our guide on
-[Collecting Custom Metrics](android-custom-metrics).
+[Collecting Custom Metrics](/docs/android/android-custom-metrics).


### PR DESCRIPTION
@dmyablonski noticed this URL issue; affects any link that isn't either
absolute or relative or includes the `.mdx` trailing file extension.

Install ripgrep with this command to get PCRE2:

```bash
❯ cargo install ripgrep --features 'pcre2'
```

Then use this spicy command to find URLs that likely have the issue
(also uses fd-find):

```bash
❯ rg --engine pcre2 '\]\([^/h#\.](?![^/:]*?\.mdx)[^:/]*?\)' $(fd '\.mdx' | sort)
```

See also
https://github.com/dmyablonski/memfault-docs/commit/01bfe5e2385303be7f056c47e43ddd82144bd64f
.
