### PR TITLE
Clarifying nRF Connect SDK support versions

### DIFF
--- a/docs/mcu/nrf-connect-sdk-guide.mdx
+++ b/docs/mcu/nrf-connect-sdk-guide.mdx
@@ -13,11 +13,12 @@ import TabItem from "@theme/TabItem";
 In this guide we will walk through the steps for integrating the
 [Memfault Firmware SDK](https://github.com/memfault/memfault-firmware-sdk) into
 a project using the nRF Connect SDK. The integration has been tested against the
-releases ranging from v1.4.0 up to v1.6.0.
+releases ranging from v1.4.0 up to v1.6.0. All versions of the nRF Connect SDK 
+since v1.6.0 include Memfault when downloaded from Nordic's website.
 
 :::tip
 
-nRF Connect SDK v1.6.0 has built-in support for the Memfault Firmware SDK on
+nRF Connect SDK v1.6.0, and all versions since, has built-in support for the Memfault Firmware SDK on
 nRF9160-based targets. Nordic Semiconductor has released some
 [excellent documentation](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/1.8.0/nrf/libraries/others/memfault_ncs.html)
 on how to integrate Memfault in your existing nRF Connect SDK project, together


### PR DESCRIPTION
Updating the documentation to be clear that support is not limited to v1.6 of the Nordic SDK