### PR TITLE
mcu/compact_logs: explicit `__start_log_fmt` def

### DIFF
--- a/docs/mcu/compact-logs.mdx
+++ b/docs/mcu/compact-logs.mdx
@@ -31,7 +31,7 @@ MEMFAULT_TRACE_EVENT_WITH_LOG(flash_error, "QSPI Flash Erase Failure: error code
 With a formatted string we need to encode the string length as well as the
 entire string in our binary message taking up 41 bytes
 
-```
+```plaintext
 00000000: 5153 5049 2046 6c61 7368 2045 7261 7365  QSPI Flash Erase
 00000010: 2046 6169 6c75 7265 3a20 6572 726f 7220   Failure: error
 00000020: 636f 6465 3a20 3078 35                   code: 0x5
@@ -40,7 +40,7 @@ entire string in our binary message taking up 41 bytes
 where as with a compact log we need to encode a integer id and the arguments to
 be serialized which in this example takes a total of 5 bytes
 
-```
+```plaintext
 00000000: 8218 8805                                ....
 ```
 
@@ -63,13 +63,17 @@ Add the following to your projects `memfault_platform_config.h`:
 Locate the linker script for your project (usually ends with `.ld`) and add the
 following to your linker script
 
-```
+```linker-script
     log_fmt 0xF0000000 (INFO):
     {
-       KEEP(*(*.log_fmt_hdr))
-       KEEP(*(log_fmt))
+        /*
+        Note: binutils >= 0.29 will automatically create this symbol but we set
+        it explicitly for compatibility with older versions
+        */
+        __start_log_fmt = ABSOLUTE(.);
+        KEEP(*(*.log_fmt_hdr))
+        KEEP(*(log_fmt))
     }
-
 ```
 
 ## FAQ
@@ -78,7 +82,7 @@ following to your linker script
 
 Once enabled, if you see the following compiler error:
 
-```
+```plaintext
 memfault/core/compiler_gcc.h:73:45: error: static assertion failed: "## operator not supported, enable gnu extensions on your compiler"
  #  define MEMFAULT_STATIC_ASSERT(cond, msg) _Static_assert(cond, msg)
 ```

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -22,6 +22,7 @@ module.exports = {
         },
         prism: {
             theme: require("prism-react-renderer/themes/oceanicNext"),
+            additionalLanguages: ["linker-script"],
         },
         navbar: {
             title: "Memfault Docs",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
         "classnames": "^2.2.6",
         "core-js": "^3.4.1",
         "mobx": "^4.2.0",
+        "prismjs": "^1.28.0",
         "query-string": "^7.0.0",
         "react": "^16.12.0",
         "react-dom": "^16.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10970,6 +10970,11 @@ prismjs@^1.27.0:
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.27.0.tgz#bb6ee3138a0b438a3653dd4d6ce0cc6510a45057"
   integrity sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==
 
+prismjs@^1.28.0:
+  version "1.28.0"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.28.0.tgz#0d8f561fa0f7cf6ebca901747828b149147044b6"
+  integrity sha512-8aaXdYvl1F7iC7Xm1spqSaY/OJBpYW3v+KJ+F17iYxvdc8sfjW194COK5wVhMZX45tGteiBQgdvD/nhxcRwylw==
+
 process-es6@^0.11.6:
   version "0.11.6"
   resolved "https://registry.yarnpkg.com/process-es6/-/process-es6-0.11.6.tgz#c6bb389f9a951f82bd4eb169600105bd2ff9c778"


### PR DESCRIPTION
Some older versions of binutils don't seem to reliably place the
`__start_SECTION` automatic symbol, so include an explicit definition so
our compact log decoding will work. An example of a toolchain with the
problem is this one:

https://github.com/espressif/esp-idf/blob/v4.2.3/tools/tools.json#L30

Update our copy of `prismjs` to support _cutting edge_ GNU linker-script
syntax highlighting:

https://github.com/PrismJS/prism/pull/3373