### PR TITLE
Add links to all generated breadcrumbs

### DIFF
--- a/docs/mcu/arm-cortex-m-guide.mdx
+++ b/docs/mcu/arm-cortex-m-guide.mdx
@@ -2,6 +2,7 @@
 id: arm-cortex-m-guide
 title: ARM Cortex-M Integration Guide
 sidebar_label: ARM Cortex-M
+description: "Integrate Memfault for a Cortex-M device."
 ---
 
 import ProjectAwareCreateAProject from "@site/src/components/ProjectAwareCreateAProject";

--- a/docs/mcu/da1469x-sdk-guide.mdx
+++ b/docs/mcu/da1469x-sdk-guide.mdx
@@ -2,24 +2,16 @@
 id: da1469x-sdk-guide
 title: DA1469x SDK Integration Guide
 sidebar_label: Dialog DA1469x
+description: "Integrate Memfault for Dialog's DA1469x product family."
 ---
 
-import SendingDataOverUdp from "@site/src/pages/_partials/_sending-data-over-udp.mdx";
-
 import ProjectAwareCreateAProject from "@site/src/components/ProjectAwareCreateAProject";
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
 
 import UploadSymbolFile from "@site/src/pages/_partials/_steps/_upload-symbol-file.mdx";
-import DataTransferTroubleshooting from "@site/src/pages/_partials/_steps/_data-transfer-troubleshooting.mdx";
 import PostChunksLocally from "@site/src/pages/_partials/_steps/_post-chunks-locally.mdx";
-import PublishDataToCloud from "@site/src/pages/_partials/_steps/_publish-data-to-cloud.mdx";
 import DefineFirstTraceEvent from "@site/src/pages/_partials/_steps/_define-first-trace-event.mdx";
 import DefineFirstHeartbeat from "@site/src/pages/_partials/_steps/_define-first-heartbeat.mdx";
 import AddCliTestCommands from "@site/src/pages/_partials/_steps/_add-cli-test-commands.mdx";
-import FwSdkFeatures from "@site/src/pages/_partials/_steps/_sdk-features.mdx";
-import MetricTimerDependency from "@site/src/pages/_partials/_steps/_metric-timer-dependency.mdx";
-import RebootTrackingDependency from "@site/src/pages/_partials/_steps/_reboot-tracking-dependency.mdx";
 
 ## Overview
 

--- a/docs/mcu/esp8266-rtos-sdk-guide.mdx
+++ b/docs/mcu/esp8266-rtos-sdk-guide.mdx
@@ -2,6 +2,7 @@
 id: esp8266-rtos-sdk-guide
 title: ESP8266 RTOS Integration Guide
 sidebar_label: ESP8266 RTOS SDK
+description: "Integrate Memfault for the ESP8266 RTOS SDK."
 ---
 
 import ProjectAwareCreateAProject from "@site/src/components/ProjectAwareCreateAProject";

--- a/docs/mcu/nrf-connect-sdk-guide.mdx
+++ b/docs/mcu/nrf-connect-sdk-guide.mdx
@@ -2,6 +2,7 @@
 id: nrf-connect-sdk-guide
 title: nRF Connect SDK Integration Guide
 sidebar_label: nRF Connect SDK
+description: "Integrate Memfault using the nRF Connect SDK."
 ---
 
 import SendingDataOverUdp from "@site/src/pages/_partials/_sending-data-over-udp.mdx";

--- a/docs/mcu/pinnacle-100-guide.mdx
+++ b/docs/mcu/pinnacle-100-guide.mdx
@@ -2,6 +2,7 @@
 id: pinnacle-100-guide
 title: Pinnacle™ 100 Modem Integration Guide
 sidebar_label: Laird Pinnacle™ 100
+description: "Integrate Memfault using Laird's Pinnacle™ 100 Cellular Modem."
 ---
 
 import MqttTopic from "@site/src/pages/_partials/_mqtt/_topic.mdx";

--- a/docs/mcu/symbol-file-build-ids.mdx
+++ b/docs/mcu/symbol-file-build-ids.mdx
@@ -2,6 +2,7 @@
 id: symbol-file-build-ids
 title: Symbol Files & Build Ids
 sidebar_label: Symbol Files & Build Ids
+description: "Learn how Memfault identifies symbols to match them to versions."
 ---
 
 import AddBuildId from "@site/src/pages/_partials/_steps/_add-build-id.mdx";

--- a/sidebars.js
+++ b/sidebars.js
@@ -10,7 +10,7 @@ module.exports = {
         {
             type: "category",
             label: "Web Application",
-            link: { type: "generated-index" },
+            link: { type: "doc", id: "platform/projects-and-fleets" },
             items: [
                 "platform/memfault-terminology",
                 "platform/projects-and-fleets",
@@ -31,7 +31,7 @@ module.exports = {
         },
         {
             type: "category",
-            link: { type: "generated-index" },
+            link: { type: "doc", id: "mcu/introduction" },
             label: "MCU Guides",
             items: [
                 "mcu/introduction",
@@ -100,7 +100,7 @@ module.exports = {
         {
             label: "Android Guides",
             type: "category",
-            link: { type: "generated-index" },
+            link: { type: "doc", id: "android/introduction" },
             items: [
                 "android/introduction",
                 "android/android-getting-started-guide",
@@ -118,7 +118,7 @@ module.exports = {
         {
             label: "Linux Guides",
             type: "category",
-            link: { type: "generated-index" },
+            link: { type: "doc", id: "linux/introduction" },
             items: [
                 "linux/introduction",
                 "linux/linux-releases-integration-guide",
@@ -137,7 +137,7 @@ module.exports = {
         {
             label: "Troubleshooting",
             type: "category",
-            link: { type: "generated-index" },
+            link: { type: "doc", id: "troubleshooting/uploading-symbol-file-is-invalid" },
             items: ["troubleshooting/uploading-symbol-file-is-invalid"],
         },
     ],

--- a/sidebars.js
+++ b/sidebars.js
@@ -6,104 +6,140 @@
  */
 
 module.exports = {
-    docs: {
-        "Web Application": [
-            "platform/memfault-terminology",
-            "platform/projects-and-fleets",
-            "platform/inspecting-a-device",
-            "platform/software-version-hardware-version",
-            "platform/jira-integration",
-            "platform/user-management",
-            "platform/organization-auth-tokens",
-            "platform/issue-management",
-            "platform/ota",
-            "platform/metrics",
-            "platform/charts",
-            "platform/alerts",
-            "platform/rate-limiting",
-            /* "platform/bulk-device-upload", */
-            /* Mentions features to be released: "platform/sso", */
-        ],
-        "MCU Guides": [
-            "mcu/introduction",
-            {
-                type: "category",
-                label: "Getting Started Guides",
-                items: [
-                    "mcu/arm-cortex-m-guide",
-                    "mcu/nrf-connect-sdk-guide",
-                    "mcu/pinnacle-100-guide",
-                    "mcu/esp32-guide",
-                    "mcu/esp8266-rtos-sdk-guide",
-                    "mcu/da1469x-sdk-guide",
-                ],
-            },
-            {
-                type: "category",
-                label: "Subsystem Guides",
-                items: [
-                    "mcu/coredumps",
-                    "mcu/compact-logs",
-                    "mcu/reboot-reason-tracking",
-                    "mcu/metrics-api",
-                    "mcu/trace-events",
-                    "mcu/logging",
-                    "mcu/releases-integration-guide",
-                    "mcu/symbol-file-build-ids",
-                    "mcu/heap-stats",
-                    "mcu/rtos-analysis",
-                ],
-            },
-            {
-                type: "category",
-                label: "User Guides",
-                items: [
-                    "mcu/coredump-elf-with-gdb",
-                    "mcu/uploading-data-with-mqtt",
-                    "mcu/sdk-submodule",
-                ],
-            },
-            {
-                type: "category",
-                label: "Design Docs",
-                items: [
-                    "mcu/data-from-firmware-to-the-cloud",
-                    "mcu/event-serialization-overview",
-                ],
-            },
-            {
-                type: "category",
-                label: "Test Utilities",
-                items: [
-                    "mcu/test-patterns-for-chunks-endpoint",
-                    "mcu/test-data-collection-with-gdb",
-                    "mcu/export-chunks-over-console",
-                    "mcu/demo-cli",
-                ],
-            },
-        ],
-        "Android Guides": [
-            "android/introduction",
-            "android/android-getting-started-guide",
-            "android/android-bort",
-            "android/uploading-android-bugreports",
-            "android/android-reboot-events",
-            "android/custom-events",
-            "android/android-builtin-metrics",
-            "android/android-custom-metrics",
-            "android/android-releases-integration-guide",
-            "android/android-ota-update-client",
-            "android/android-data-scrubbing",
-        ],
-        "Embedded Linux Guides": [
-            "linux/introduction",
-            "linux/linux-releases-integration-guide",
-        ],
-        "Automation, CI & CD": [
-            "ci/authentication",
-            "ci/install-memfault-cli",
-            "ci/add-device-to-cohort-api",
-        ],
-        Troubleshooting: ["troubleshooting/uploading-symbol-file-is-invalid"],
-    },
+    docs: [
+        {
+            type: "category",
+            label: "Web Application",
+            link: { type: "generated-index" },
+            items: [
+                "platform/memfault-terminology",
+                "platform/projects-and-fleets",
+                "platform/inspecting-a-device",
+                "platform/software-version-hardware-version",
+                "platform/jira-integration",
+                "platform/user-management",
+                "platform/organization-auth-tokens",
+                "platform/issue-management",
+                "platform/ota",
+                "platform/metrics",
+                "platform/charts",
+                "platform/alerts",
+                "platform/rate-limiting"
+                /* "platform/bulk-device-upload", */
+                /* Mentions features to be released: "platform/sso", */
+            ]
+        },
+        {
+            type: "category",
+            link: { type: "generated-index" },
+            label: "MCU Guides",
+            items: [
+                "mcu/introduction",
+                {
+                    type: "category",
+                    link: { type: "generated-index" },
+                    label: "Getting Started Guides",
+                    items: [
+                        "mcu/arm-cortex-m-guide",
+                        "mcu/nrf-connect-sdk-guide",
+                        "mcu/pinnacle-100-guide",
+                        "mcu/esp32-guide",
+                        "mcu/esp8266-rtos-sdk-guide",
+                        "mcu/da1469x-sdk-guide"
+                    ]
+                },
+                {
+                    type: "category",
+                    link: { type: "generated-index" },
+                    label: "Subsystem Guides",
+                    items: [
+                        "mcu/coredumps",
+                        "mcu/compact-logs",
+                        "mcu/reboot-reason-tracking",
+                        "mcu/metrics-api",
+                        "mcu/trace-events",
+                        "mcu/logging",
+                        "mcu/releases-integration-guide",
+                        "mcu/symbol-file-build-ids",
+                        "mcu/heap-stats",
+                        "mcu/rtos-analysis"
+                    ]
+                },
+                {
+                    type: "category",
+                    link: { type: "generated-index" },
+                    label: "User Guides",
+                    items: [
+                        "mcu/coredump-elf-with-gdb",
+                        "mcu/uploading-data-with-mqtt",
+                        "mcu/sdk-submodule"
+                    ]
+                },
+                {
+                    type: "category",
+                    link: { type: "generated-index" },
+                    label: "Design Docs",
+                    items: [
+                        "mcu/data-from-firmware-to-the-cloud",
+                        "mcu/event-serialization-overview"
+                    ]
+                },
+                {
+                    type: "category",
+                    link: { type: "generated-index" },
+                    label: "Test Utilities",
+                    items: [
+                        "mcu/test-patterns-for-chunks-endpoint",
+                        "mcu/test-data-collection-with-gdb",
+                        "mcu/export-chunks-over-console",
+                        "mcu/demo-cli"
+                    ]
+                }
+            ]
+        },
+        {
+            label: "Android Guides",
+            type: "category",
+            link: { type: "generated-index" },
+            items: [
+                "android/introduction",
+                "android/android-getting-started-guide",
+                "android/android-bort",
+                "android/uploading-android-bugreports",
+                "android/android-reboot-events",
+                "android/custom-events",
+                "android/android-builtin-metrics",
+                "android/android-custom-metrics",
+                "android/android-releases-integration-guide",
+                "android/android-ota-update-client",
+                "android/android-data-scrubbing"
+            ]
+        },
+        {
+            label: "Linux Guides",
+            type: "category",
+            link: { type: "generated-index" },
+            items: [
+                "linux/introduction",
+                "linux/linux-releases-integration-guide"
+            ]
+        },
+        {
+            label: "Automation, CI & CD",
+            type: "category",
+            link: { type: "generated-index" },
+            items: [
+                "ci/authentication",
+                "ci/install-memfault-cli",
+                "ci/add-device-to-cohort-api"
+            ]
+        },
+        {
+            label: "Troubleshooting",
+            type: "category",
+            link: { type: "generated-index" },
+            items: ["troubleshooting/uploading-symbol-file-is-invalid"]
+        }
+    ]
 };
+

--- a/sidebars.js
+++ b/sidebars.js
@@ -24,10 +24,10 @@ module.exports = {
                 "platform/metrics",
                 "platform/charts",
                 "platform/alerts",
-                "platform/rate-limiting"
+                "platform/rate-limiting",
                 /* "platform/bulk-device-upload", */
                 /* Mentions features to be released: "platform/sso", */
-            ]
+            ],
         },
         {
             type: "category",
@@ -45,8 +45,8 @@ module.exports = {
                         "mcu/pinnacle-100-guide",
                         "mcu/esp32-guide",
                         "mcu/esp8266-rtos-sdk-guide",
-                        "mcu/da1469x-sdk-guide"
-                    ]
+                        "mcu/da1469x-sdk-guide",
+                    ],
                 },
                 {
                     type: "category",
@@ -62,8 +62,8 @@ module.exports = {
                         "mcu/releases-integration-guide",
                         "mcu/symbol-file-build-ids",
                         "mcu/heap-stats",
-                        "mcu/rtos-analysis"
-                    ]
+                        "mcu/rtos-analysis",
+                    ],
                 },
                 {
                     type: "category",
@@ -72,8 +72,8 @@ module.exports = {
                     items: [
                         "mcu/coredump-elf-with-gdb",
                         "mcu/uploading-data-with-mqtt",
-                        "mcu/sdk-submodule"
-                    ]
+                        "mcu/sdk-submodule",
+                    ],
                 },
                 {
                     type: "category",
@@ -81,8 +81,8 @@ module.exports = {
                     label: "Design Docs",
                     items: [
                         "mcu/data-from-firmware-to-the-cloud",
-                        "mcu/event-serialization-overview"
-                    ]
+                        "mcu/event-serialization-overview",
+                    ],
                 },
                 {
                     type: "category",
@@ -92,10 +92,10 @@ module.exports = {
                         "mcu/test-patterns-for-chunks-endpoint",
                         "mcu/test-data-collection-with-gdb",
                         "mcu/export-chunks-over-console",
-                        "mcu/demo-cli"
-                    ]
-                }
-            ]
+                        "mcu/demo-cli",
+                    ],
+                },
+            ],
         },
         {
             label: "Android Guides",
@@ -112,8 +112,8 @@ module.exports = {
                 "android/android-custom-metrics",
                 "android/android-releases-integration-guide",
                 "android/android-ota-update-client",
-                "android/android-data-scrubbing"
-            ]
+                "android/android-data-scrubbing",
+            ],
         },
         {
             label: "Linux Guides",
@@ -121,8 +121,8 @@ module.exports = {
             link: { type: "generated-index" },
             items: [
                 "linux/introduction",
-                "linux/linux-releases-integration-guide"
-            ]
+                "linux/linux-releases-integration-guide",
+            ],
         },
         {
             label: "Automation, CI & CD",
@@ -131,15 +131,14 @@ module.exports = {
             items: [
                 "ci/authentication",
                 "ci/install-memfault-cli",
-                "ci/add-device-to-cohort-api"
-            ]
+                "ci/add-device-to-cohort-api",
+            ],
         },
         {
             label: "Troubleshooting",
             type: "category",
             link: { type: "generated-index" },
-            items: ["troubleshooting/uploading-symbol-file-is-invalid"]
-        }
-    ]
+            items: ["troubleshooting/uploading-symbol-file-is-invalid"],
+        },
+    ],
 };
-

--- a/sidebars.js
+++ b/sidebars.js
@@ -137,7 +137,10 @@ module.exports = {
         {
             label: "Troubleshooting",
             type: "category",
-            link: { type: "doc", id: "troubleshooting/uploading-symbol-file-is-invalid" },
+            link: {
+                type: "doc",
+                id: "troubleshooting/uploading-symbol-file-is-invalid",
+            },
             items: ["troubleshooting/uploading-symbol-file-is-invalid"],
         },
     ],


### PR DESCRIPTION
This fixes an issue whereby generated breadcrumbs would include SEO
microcode that got picked up as invalid by Google due to invalid IDs
being inferred from them.

For full context, see the issue I posted on Docusaurus:
https://github.com/facebook/docusaurus/issues/7241

A way out of this would be to remove the breadcrumbs, but I opted for
adding a generated index page to each category in the sidebar in order
to give every breadcrumb item a link.

![image](https://user-images.githubusercontent.com/16181067/165091067-3b451566-d8bb-4612-a18b-abf144283238.png)
_The generated pages look like this. Their existence makes the breadcrumb item clickable, and thus valid in the eyes of Google._