### PR TITLE
Update arm-mcuxpresso-guide.mdx

### DIFF
--- a/docs/mcu/arm-mcuxpresso-guide.mdx
+++ b/docs/mcu/arm-mcuxpresso-guide.mdx
@@ -1,7 +1,7 @@
 ---
 id: arm-mcuxpresso-guide
-title: MCUXpresso Getting Started Guide for ARM
-sidebar_label: MCUXpresso SDK for i.MX RT
+title: NXP MCUXpresso Getting Started Guide for ARM
+sidebar_label: NXP MCUXpresso SDK for i.MX RT
 ---
 
 This tutorial will go over integrating the


### PR DESCRIPTION
Updating the page title and the side bar label so when you search "NXP" in the docs, this guide will pop up first since it doesn't right now.

I also think we should update the URL to https://docs.memfault.com/docs/mcu/nxp-mcuxpresso-guide/ or https://docs.memfault.com/docs/mcu/arm-nxp-mcuxpresso-guide/ so NXP is included in the URL for SEO and search, but I understand this may be a bigger ask and cause issues with the NXPlanding page integration.


![Snip20220525_2](https://user-images.githubusercontent.com/14300934/170390007-90b9bd92-5de3-4075-ace9-1bfa38c3107e.png)

