### PR TITLE
Remove yocto layer link

### DIFF
--- a/docs/linux/linux-releases-integration-guide.mdx
+++ b/docs/linux/linux-releases-integration-guide.mdx
@@ -272,23 +272,6 @@ Your device may require a different `postupdatecmd` than `reboot`.
 
 `swupdate -f /etc/swupdate.cfg`
 
-#### Integration with Yocto
-
-:::warning
-
-This section has not been updated for our hawkBit DDI API implementation.
-
-:::
-
-The [`meta-memfault-swupdate-example`][6] Yocto layer is based on [SWUpdate
-documentation on building with Yocto][7] and should serve as an example of
-building your own Linux image that contains SWUpdate preconfigured to work with
-Memfault.
-
-We have prepared [a `Dockerfile`][8] that serves as an example of using
-`meta-memfault-swupdate-example` as part of a Poky build. Read more about
-`meta-memfault-swupdate-example` in [the project `README`][6].
-
   </TabItem>
   <TabItem value="custom">
 

--- a/docs/linux/linux-releases-integration-guide.mdx
+++ b/docs/linux/linux-releases-integration-guide.mdx
@@ -272,6 +272,11 @@ Your device may require a different `postupdatecmd` than `reboot`.
 
 `swupdate -f /etc/swupdate.cfg`
 
+#### Integration with Yocto
+
+Please follow external docs (such as [SWUpdate documentation on building with
+Yocto][7]) for instructions on how to set up and build an SWUpdate Yocto layer.
+
   </TabItem>
   <TabItem value="custom">
 
@@ -352,7 +357,4 @@ under "Options" and select the "Abort Rollout" option.
 [3]: https://sbabic.github.io/swupdate
 [4]: https://sbabic.github.io/swupdate/suricatta.html
 [5]: https://www.eclipse.org/hawkbit/apis/ddi_api/
-[6]:
-  https://github.com/memfault/memfault-yocto/tree/main/meta-memfault-swupdate-example
 [7]: https://sbabic.github.io/swupdate/building-with-yocto.html
-[8]: https://github.com/memfault/memfault-yocto/blob/main/Dockerfile.swupdate


### PR DESCRIPTION
### Issues addressed
 The old yocto layer is no longer relevant, but the new one isn't ready
 yet.

  ### Summary of changes
  Remove the link. Customers will have to generate their own yocto layer.