### PR TITLE
Add note about HTTP pipelining not supported

### DIFF
--- a/docs/mcu/data-from-firmware-to-the-cloud.mdx
+++ b/docs/mcu/data-from-firmware-to-the-cloud.mdx
@@ -54,6 +54,10 @@ HTTP API is the only integration work which needs to be done to get the data
   concurrently, ensure that requests for _the same device_ cannot happen
   concurrently, to avoid violating the ordering requirement. Out of order chunks
   will be best-effort reordered on the Memfault server.
+  - HTTP requests should not be
+    [pipelined](https://en.wikipedia.org/wiki/HTTP_pipelining). That is, the
+    HTTP response for a POST must be received before the next HTTP request can
+    be sent.
 - To minimize overhead and optimize throughput, batch-upload chunks to the
   [chunks HTTP API](https://api-docs.memfault.com/) using `multipart/mixed`
   requests and re-use HTTP connections to Memfault's servers.


### PR DESCRIPTION
Occassionally I get questions about whether clients need to wait for a
chunk upload request's HTTP response before sending another request. In
practice it seems to be required, possibly because of how nginx is
configured or we have some modules that don't support it :shrug:.

Add a note specifying that it's not supported.

FWIW I tested quickly to see what happens with pipelined requests.

Doing it with `ncat` (which is quite brutal and should be pretty close
to what a simple MCU transfer might do), we only end up getting the
first POST request.

Doing it with `openssl s_client` results in both requests received. It
might be doing something smarter with a `Expect: 100-continue` header or
something, not sure 😕. Here's the openssl command I ran that works
correctly:

```bash
❯ openssl s_client -connect chunks.memfault.com:443 < double_chunk_with_header.bin
```

Here's the example `ncat` that shows the error:

```bash
❯ printf 'POST /api/v0/chunks/TESTSERIAL HTTP/1.1
Host: chunks.memfault.com
user-agent: curl/7.74.0
accept: */*
memfault-project-key: bf8KeeFTRvoO0XOnXbwYzWL8GNT9QK6X
content-type: application/octet-stream
content-length: 87\n\n' | cat - ~/Downloads/chunk_v2_single_chunk_msg-f48b401be2528a137495ab4f8ec2202f.bin > chunk_with_header.bin

❯ sponge < chunk_with_header.bin >> chunk_with_header.bin

❯ ncat --ssl -v chunks.memfault.com 443 < double_chunk_with_header.bin
Ncat: Version 7.80 ( https://nmap.org/ncat )
Ncat: SSL connection to 52.7.61.29:443. Memfault, Inc.
Ncat: SHA-1 fingerprint: 3A04 6FB3 0F0B 3AB2 AB10 8D17 5ED6 03C7 90AD C43C
Ncat: 606 bytes sent, 0 bytes received in 0.47 seconds.
```