### PR TITLE
MFLT-6637 Update Linux SDK instructions to include SSL

### DIFF
--- a/docs/android/android-getting-started-guide.mdx
+++ b/docs/android/android-getting-started-guide.mdx
@@ -220,8 +220,9 @@ that you wish to validate. Connect that device via ADB (verify via
 
 :::info
 
-We recommend running the validation tool with a `userdebug` system image. A `user` image does not allow
-all checks to be run, which may result in Bort configuration issues being missed.
+We recommend running the validation tool with a `userdebug` system image. A
+`user` image does not allow all checks to be run, which may result in Bort
+configuration issues being missed.
 
 :::
 

--- a/docs/linux/linux-releases-integration-guide.mdx
+++ b/docs/linux/linux-releases-integration-guide.mdx
@@ -207,9 +207,6 @@ Find the following options, either via `menuconfig` or by modifying `defconfig`:
 - `CONFIG_SURICATTA_HAWKBIT=y`: configures Suricatta to use hawkBit server mode.
 - Unset `CONFIG_SURICATTA_GENERAL`: SWUpdate works either in hawkBit mode or a
   general-purpose HTTP server mode. Disable general-purpose HTTP server support.
-- Unset `CONFIG_SURICATTA_SSL`: We distribute our binaries over https but do not
-  yet have full support for client-side configured SSL (which requires uploading
-  a SHA1 hash of the binary).
 
 #### Configuring the Suricatta on-device daemon to use Memfault
 


### PR DESCRIPTION
Remove instructions to unset SSL

 ### Issues addressed
These instructions were required before we had SHA hashes for Linux OTA
artifacts. However, we recently added SHA hashes for artifacts and these
instructions are not required.

 ### Summary of changes
Remove the disable SSL instructions.

 ### Test plan
Followed this advice in the QEMU environment and confirmed I could still
do an update.

