### PR TITLE
metrics-for-battery-life: fixup charge drop calculations

### DIFF
--- a/docs/best_practices/metrics-for-battery-life.mdx
+++ b/docs/best_practices/metrics-for-battery-life.mdx
@@ -150,7 +150,7 @@ aggregation.
 - To report a drop from 87% to 84% over the course of the heartbeat interval,
   report 300.
 - To report a battery charge level drop of 10 mAh out of a 500 mAh capacity
-  battery, record 2000.
+  battery, record 200.
 - If the battery charge level drop could not be acquired or it is known to be
   invalid or negative, record -1.
 
@@ -326,7 +326,7 @@ $$
 Projected\ \#\ Hours\ of\ Battery\ Life = \frac{100}{Average\ Battery\ Charge\ Drop\ Per\ Hour}
 $$
 
-For example, if the average battery charge drop per hour was 1.2.
+For example, if the average battery charge drop per hour was 2.2.
 
 $$
 \frac{100}{2.2} = 45.5\ hours\ of\ expected\ battery\ life


### PR DESCRIPTION
Went through the page again and found a couple of small mistakes in calculations for the charge level drop examples.