### PR TITLE
MFLT-8288 Move data transfer troubleshooting to separate page

### DIFF
--- a/docs/mcu/arm-cortex-m-guide.mdx
+++ b/docs/mcu/arm-cortex-m-guide.mdx
@@ -18,7 +18,6 @@ import RtosPorts from "@site/src/pages/_partials/_steps/_rtos-ports.mdx";
 import CoredumpDependency from "@site/src/pages/_partials/_steps/_coredump-dependency.mdx";
 import RegisterAssert from "@site/src/pages/_partials/_steps/_register-assert.mdx";
 import UploadSymbolFile from "@site/src/pages/_partials/_steps/_upload-symbol-file.mdx";
-import DataTransferTroubleshooting from "@site/src/pages/_partials/_steps/_data-transfer-troubleshooting.mdx";
 import PostChunksLocally from "@site/src/pages/_partials/_steps/_post-chunks-locally.mdx";
 import PublishDataToCloud from "@site/src/pages/_partials/_steps/_publish-data-to-cloud.mdx";
 import DefineFirstTraceEvent from "@site/src/pages/_partials/_steps/_define-first-trace-event.mdx";
@@ -131,8 +130,7 @@ instrumentation, and test the integration!
 <UploadSymbolFile />
 
 ### Troubleshooting Data Transfer
-
-<DataTransferTroubleshooting />
+See the docs on [data transfer troubleshooting](/docs/troubleshooting/data-transfer-troubleshooting).
 
 ## Data Transport Steps
 

--- a/docs/mcu/arm-cortex-m-guide.mdx
+++ b/docs/mcu/arm-cortex-m-guide.mdx
@@ -130,7 +130,9 @@ instrumentation, and test the integration!
 <UploadSymbolFile />
 
 ### Troubleshooting Data Transfer
-See the docs on [data transfer troubleshooting](/docs/troubleshooting/data-transfer-troubleshooting).
+
+See the docs on
+[data transfer troubleshooting](/docs/troubleshooting/data-transfer-troubleshooting).
 
 ## Data Transport Steps
 

--- a/docs/mcu/arm-gcc-guide.mdx
+++ b/docs/mcu/arm-gcc-guide.mdx
@@ -294,7 +294,9 @@ You can programmatically upload symbol files with the
 :::
 
 ### Troubleshooting Data Transfer
-See the docs on [data transfer troubleshooting](/docs/troubleshooting/data-transfer-troubleshooting).
+
+See the docs on
+[data transfer troubleshooting](/docs/troubleshooting/data-transfer-troubleshooting).
 
 ### Next Steps
 

--- a/docs/mcu/arm-gcc-guide.mdx
+++ b/docs/mcu/arm-gcc-guide.mdx
@@ -294,18 +294,7 @@ You can programmatically upload symbol files with the
 :::
 
 ### Troubleshooting Data Transfer
-
-If you run into any issues with your data transfer implementation, we have tools
-to help!
-
-- A UI you can use to
-  [view the raw "Chunk" data payloads](/docs/mcu/test-patterns-for-chunks-endpoint#troubleshooting)
-  that have arrived for your project.
-- [Precanned Data Payloads](/docs/mcu/test-patterns-for-chunks-endpoint) you can
-  pass through your `user_transport_send_chunk_data()` implementation to test
-  data transfer in isolation.
-- A [GDB Script](/docs/mcu/test-data-collection-with-gdb) which can be installed
-  to send chunks programmatically every time a breakpoint is hit.
+See the docs on [data transfer troubleshooting](/docs/troubleshooting/data-transfer-troubleshooting).
 
 ### Next Steps
 

--- a/docs/mcu/arm-infineon-modustoolbox-guide.mdx
+++ b/docs/mcu/arm-infineon-modustoolbox-guide.mdx
@@ -310,7 +310,9 @@ build/CY8CKIT-062S2-43012/Debug/your_application.elf
 <UploadSymbolFile />
 
 ### Troubleshooting Data Transfer
-See the docs on [data transfer troubleshooting](/docs/troubleshooting/data-transfer-troubleshooting).
+
+See the docs on
+[data transfer troubleshooting](/docs/troubleshooting/data-transfer-troubleshooting).
 
 ## Data Transport Steps
 

--- a/docs/mcu/arm-infineon-modustoolbox-guide.mdx
+++ b/docs/mcu/arm-infineon-modustoolbox-guide.mdx
@@ -6,7 +6,6 @@ sidebar_label: ModusToolbox™ SDK for PSoC™ 6
 
 import UploadSymbolFile from "@site/src/pages/_partials/_steps/_upload-symbol-file.mdx";
 import PostChunksLocally from "@site/src/pages/_partials/_steps/_post-chunks-locally.mdx";
-import DataTransferTroubleshooting from "@site/src/pages/_partials/_steps/_data-transfer-troubleshooting.mdx";
 import PublishDataToCloud from "@site/src/pages/_partials/_steps/_publish-data-to-cloud.mdx";
 import AddCliTestCommands from "@site/src/pages/_partials/_steps/_add-cli-test-commands.mdx";
 
@@ -311,8 +310,7 @@ build/CY8CKIT-062S2-43012/Debug/your_application.elf
 <UploadSymbolFile />
 
 ### Troubleshooting Data Transfer
-
-<DataTransferTroubleshooting />
+See the docs on [data transfer troubleshooting](/docs/troubleshooting/data-transfer-troubleshooting).
 
 ## Data Transport Steps
 

--- a/docs/mcu/esp8266-rtos-sdk-guide.mdx
+++ b/docs/mcu/esp8266-rtos-sdk-guide.mdx
@@ -331,15 +331,4 @@ You can programmatically upload symbol files with the
 :::
 
 ### Troubleshooting Data Transfer
-
-If you run into any issues with your data transfer implementation, we have tools
-to help!
-
-- A UI you can use to
-  [view the raw "Chunk" data payloads](/docs/mcu/test-patterns-for-chunks-endpoint#troubleshooting)
-  that have arrived for your project.
-- [Precanned Data Payloads](/docs/mcu/test-patterns-for-chunks-endpoint) you can
-  pass through your `user_transport_send_chunk_data()` implementation to test
-  data transfer in isolation.
-- A [GDB Script](/docs/mcu/test-data-collection-with-gdb) which can be installed
-  to send chunks programmatically every time a breakpoint is hit.
+See the docs on [data transfer troubleshooting](/docs/troubleshooting/data-transfer-troubleshooting).

--- a/docs/mcu/esp8266-rtos-sdk-guide.mdx
+++ b/docs/mcu/esp8266-rtos-sdk-guide.mdx
@@ -331,4 +331,6 @@ You can programmatically upload symbol files with the
 :::
 
 ### Troubleshooting Data Transfer
-See the docs on [data transfer troubleshooting](/docs/troubleshooting/data-transfer-troubleshooting).
+
+See the docs on
+[data transfer troubleshooting](/docs/troubleshooting/data-transfer-troubleshooting).

--- a/docs/mcu/nrf-connect-sdk-guide.mdx
+++ b/docs/mcu/nrf-connect-sdk-guide.mdx
@@ -512,7 +512,9 @@ You can programmatically upload symbol files with the
 :::
 
 ### Troubleshooting Data Transfer
-See the docs on [data transfer troubleshooting](/docs/troubleshooting/data-transfer-troubleshooting).
+
+See the docs on
+[data transfer troubleshooting](/docs/troubleshooting/data-transfer-troubleshooting).
 
 ## Sending data to Memfault over UDP
 

--- a/docs/mcu/nrf-connect-sdk-guide.mdx
+++ b/docs/mcu/nrf-connect-sdk-guide.mdx
@@ -512,18 +512,7 @@ You can programmatically upload symbol files with the
 :::
 
 ### Troubleshooting Data Transfer
-
-If you run into any issues with your data transfer implementation, we have tools
-to help!
-
-- A UI you can use to
-  [view the raw "Chunk" data payloads](/docs/mcu/test-patterns-for-chunks-endpoint#troubleshooting)
-  that have arrived for your project.
-- [Precanned Data Payloads](/docs/mcu/test-patterns-for-chunks-endpoint) you can
-  pass through your `user_transport_send_chunk_data()` implementation to test
-  data transfer in isolation.
-- A [GDB Script](/docs/mcu/test-data-collection-with-gdb) which can be installed
-  to send chunks programmatically every time a breakpoint is hit.
+See the docs on [data transfer troubleshooting](/docs/troubleshooting/data-transfer-troubleshooting).
 
 ## Sending data to Memfault over UDP
 

--- a/docs/mcu/self-serve-local-testing.mdx
+++ b/docs/mcu/self-serve-local-testing.mdx
@@ -5,7 +5,6 @@ sidebar_label: Local Testing
 ---
 
 import UploadSymbolFile from "@site/src/pages/_partials/_steps/_upload-symbol-file.mdx";
-import DataTransferTroubleshooting from "@site/src/pages/_partials/_steps/_data-transfer-troubleshooting.mdx";
 import PostChunksLocally from "@site/src/pages/_partials/_steps/_post-chunks-locally.mdx";
 import PublishDataToCloud from "@site/src/pages/_partials/_steps/_publish-data-to-cloud.mdx";
 import DefineFirstTraceEvent from "@site/src/pages/_partials/_steps/_define-first-trace-event.mdx";
@@ -36,8 +35,7 @@ leveraging Memfault and verify that everything is working properly.
 <UploadSymbolFile />
 
 ### Troubleshooting Data Transfer
-
-<DataTransferTroubleshooting />
+See the docs on [data transfer troubleshooting](/docs/troubleshooting/data-transfer-troubleshooting).
 
 ### Next Steps
 

--- a/docs/mcu/self-serve-local-testing.mdx
+++ b/docs/mcu/self-serve-local-testing.mdx
@@ -35,7 +35,9 @@ leveraging Memfault and verify that everything is working properly.
 <UploadSymbolFile />
 
 ### Troubleshooting Data Transfer
-See the docs on [data transfer troubleshooting](/docs/troubleshooting/data-transfer-troubleshooting).
+
+See the docs on
+[data transfer troubleshooting](/docs/troubleshooting/data-transfer-troubleshooting).
 
 ### Next Steps
 

--- a/docs/troubleshooting/data-transfer-troubleshooting.mdx
+++ b/docs/troubleshooting/data-transfer-troubleshooting.mdx
@@ -1,3 +1,9 @@
+---
+id: data-transfer-troubleshooting
+title: Data Transfer Troubleshooting
+sidebar_label: Data Transfer Troubleshooting
+---
+
 If you encounter any issues in your data transfer implementation, Memfault has
 tools to help debug!
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -179,7 +179,10 @@ module.exports = {
                 type: "doc",
                 id: "troubleshooting/uploading-symbol-file-is-invalid",
             },
-            items: ["troubleshooting/uploading-symbol-file-is-invalid"],
+            items: [
+                "troubleshooting/uploading-symbol-file-is-invalid",
+                "troubleshooting/data-transfer-troubleshooting",
+            ],
         },
     ],
 };


### PR DESCRIPTION
### Summary
Create a new doc in favor of the partial for data transfer troubleshooting.
Swap out the partial references for a link to the doc.

### Test plan
Check rendering and all pages link correctly.