### PR TITLE
Revert Removal of Edit Button

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -167,6 +167,8 @@ module.exports = {
             {
                 docs: {
                     sidebarPath: require.resolve("./sidebars.js"),
+                    editUrl:
+                        "https://github.com/memfault/memfault-docs/edit/main/",
                     remarkPlugins: [math],
                     rehypePlugins: [katex],
                 },


### PR DESCRIPTION
Reverts 15aaf7a8d235ed0384bd653870635a42bc918f08 so that we do have an edit button
now that our docs repo is public again.

![CleanShot 2022-12-23 at 13 50 03](https://user-images.githubusercontent.com/486904/209339273-1281f7e3-81d6-48e0-88de-00abf2c0d38b.gif)
