### PR TITLE
Fix Linux sdk link returns a 404

### DIFF
--- a/docs/linux/quickstart-raspberrypi.md
+++ b/docs/linux/quickstart-raspberrypi.md
@@ -47,7 +47,7 @@ The instructions on this guide are compatible with Linux and macOS (Intel and
 Apple Silicon). Windows users should be able to follow along with minimal
 adjustments.
 
-[sdk]: https://github.com/memfault/memfault-linux-sdk/blob/-/
+[sdk]: https://github.com/memfault/memfault-linux-sdk/
 
 ### Create a Docker container to build with Yocto
 

--- a/docs/linux/quickstart.mdx
+++ b/docs/linux/quickstart.mdx
@@ -32,7 +32,7 @@ The instructions on this guide are compatible with Linux and macOS (Intel and
 Apple Silicon). Windows users should be able to follow along with minimal
 adjustments.
 
-[sdk]: https://github.com/memfault/memfault-linux-sdk/blob/-/
+[sdk]: https://github.com/memfault/memfault-linux-sdk/
 
 ### Create a Docker container to build with Yocto
 


### PR DESCRIPTION
It appears the github urls no longers support a suffix of blob/-/ for the project root.