### PR TITLE
Update releases-integration-guide.mdx

### DIFF
--- a/docs/mcu/releases-integration-guide.mdx
+++ b/docs/mcu/releases-integration-guide.mdx
@@ -181,6 +181,8 @@ see. Let's assume we have the following test device:
 - `current_version`: 0.0.1
 - `device_serial`: DEMOSERIAL
 
+To find out where the latest release endpoint is please use api/v0/releases/latest/url. as described here. Please note that your device serial number will be the main identifier that will be used as the main query parameter. To check for the latest release on a device, you can look at the READMEs in your our the [iOS] (https://github.com/memfault/memfault-cloud-ios) or [Android] (https://github.com/memfault/memfault-cloud-android) repos for examples of how a phone app can do this. 
+
 #### Example Response when Newer OTA Payload Available
 
 To simplify integration with deeply embedded devices that may not have a json


### PR DESCRIPTION
To find out where the latest release endpoint is please use api/v0/releases/latest/url. as described here. Please note that your device serial number will be the main identifier that will be used as the main query parameter. To check for the latest release on a device, you can look at the READMEs in your our the [iOS] (https://github.com/memfault/memfault-cloud-ios) or [Android] (https://github.com/memfault/memfault-cloud-android) repos for examples of how a phone app can do this.